### PR TITLE
Make Status codes `static const` instead of `static final`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3 - 2018-07-25
+
+* Make fields of `StatusCode` const rather than final.
+
 ## 0.6.2 - 2018-07-19
 
 * Allow for non-ascii header values.

--- a/lib/src/shared/status.dart
+++ b/lib/src/shared/status.dart
@@ -15,47 +15,47 @@
 
 class StatusCode {
   /// The operation completed successfully.
-  static final ok = 0;
+  static const ok = 0;
 
   /// The operation was cancelled (typically by the caller).
-  static final cancelled = 1;
+  static const cancelled = 1;
 
   /// Unknown error. An example of where this error may be returned is if a
   /// Status value received from another address space belongs to an error-space
   /// that is not known in this address space. Also errors raised by APIs that
   /// do not return enough error information may be converted to this error.
-  static final unknown = 2;
+  static const unknown = 2;
 
   /// Client specified an invalid argument. Note that this differs from
   /// [failedPrecondition]. [invalidArgument] indicates arguments that are
   /// problematic regardless of the state of the system (e.g., a malformed file
   /// name).
-  static final invalidArgument = 3;
+  static const invalidArgument = 3;
 
   /// Deadline expired before operation could complete. For operations that
   /// change the state of the system, this error may be returned even if the
   /// operation has completed successfully. For example, a successful response
   /// from a server could have been delayed long enough for the deadline to
   /// expire.
-  static final deadlineExceeded = 4;
+  static const deadlineExceeded = 4;
 
   /// Some requested entity (e.g., file or directory) was not found.
-  static final notFound = 5;
+  static const notFound = 5;
 
   /// Some entity that we attempted to create (e.g., file or directory) already
   /// exists.
-  static final alreadyExists = 6;
+  static const alreadyExists = 6;
 
   /// The caller does not have permission to execute the specified operation.
   /// [permissionDenied] must not be used for rejections caused by exhausting
   /// some resource (use [resourceExhausted] instead for those errors).
   /// [permissionDenied] must not be used if the caller cannot be identified
   /// (use [unauthenticated] instead for those errors).
-  static final permissionDenied = 7;
+  static const permissionDenied = 7;
 
   /// Some resource has been exhausted, perhaps a per-user quota, or perhaps the
   /// entire file system is out of space.
-  static final resourceExhausted = 8;
+  static const resourceExhausted = 8;
 
   /// Operation was rejected because the system is not in a state required for
   /// the operation's execution. For example, directory to be deleted may be
@@ -71,14 +71,14 @@ class StatusCode {
   ///     because the directory is non-empty, [failedPrecondition] should be
   ///     returned since the client should not retry unless they have first
   ///     fixed up the directory by deleting files from it.
-  static final failedPrecondition = 9;
+  static const failedPrecondition = 9;
 
   /// The operation was aborted, typically due to a concurrency issue like
   /// sequencer check failures, transaction aborts, etc.
   ///
   /// See litmus test above for deciding between [failedPrecondition],
   /// [aborted], and [unavailable].
-  static final aborted = 10;
+  static const aborted = 10;
 
   /// Operation was attempted past the valid range. E.g., seeking or reading
   /// past end of file.
@@ -93,28 +93,28 @@ class StatusCode {
   /// [outOfRange]. We recommend using [outOfRange] (the more specific error)
   /// when it applies so that callers who are iterating through a space can
   /// easily look for an [outOfRange] error to detect when they are done.
-  static final outOfRange = 11;
+  static const outOfRange = 11;
 
   /// Operation is not implemented or not supported/enabled in this service.
-  static final unimplemented = 12;
+  static const unimplemented = 12;
 
   /// Internal errors. Means some invariants expected by underlying system has
   /// been broken. If you see one of these errors, something is very broken.
-  static final internal = 13;
+  static const internal = 13;
 
   /// The service is currently unavailable.  This is a most likely a transient
   /// condition and may be corrected by retrying with a backoff.
   ///
   /// See litmus test above for deciding between [failedPrecondition],
   /// [aborted], and [unavailable].
-  static final unavailable = 14;
+  static const unavailable = 14;
 
   /// Unrecoverable data loss or corruption.
-  static final dataLoss = 15;
+  static const dataLoss = 15;
 
   /// The request does not have valid authentication credentials for the
   /// operation.
-  static final unauthenticated = 16;
+  static const unauthenticated = 16;
 }
 
 class GrpcError {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: grpc
 description: Dart implementation of gRPC.
-version: 0.6.2
+version: 0.6.3
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/grpc-dart
 


### PR DESCRIPTION
This enables using the codes in switch statements and default values.

Fixes https://github.com/grpc/grpc-dart/issues/102