### PR TITLE
demo: fix NoSuchMethodError: No static getter 'anyIPv4' declared in class 'InternetAddress' issue on example

### DIFF
--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -89,13 +89,13 @@ class Server {
     Stream<Socket> server;
     if (security != null) {
       _secureServer = await SecureServerSocket.bind(
-          address ?? InternetAddress.anyIPv4,
+          address ?? InternetAddress.ANY_IP_V4,
           port ?? 443,
           security.securityContext);
       server = _secureServer;
     } else {
       _insecureServer = await ServerSocket.bind(
-          address ?? InternetAddress.anyIPv4, port ?? 80);
+          address ?? InternetAddress.ANY_IP_V4, port ?? 80);
       server = _insecureServer;
     }
     server.listen((socket) {


### PR DESCRIPTION
As the [document said](https://api.dartlang.org/stable/1.24.3/dart-io/InternetAddress-class.html) the param is `ANY_IP_V4` rather than `anyIpV4` anymore.