### PR TITLE
don't throw on closing channel not open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.8
+
+* Calling `terminate()` or `shutdown()` on a channel doesn't throw error if the
+channel is not yet open.
+
 ## 0.6.7
 
 * Support package:test 1.5.

--- a/lib/src/client/channel.dart
+++ b/lib/src/client/channel.dart
@@ -44,19 +44,19 @@ class ClientChannel {
   ///
   /// No further RPCs can be made on this channel. RPCs already in progress will
   /// be allowed to complete.
-  Future<Null> shutdown() {
-    if (_isShutdown) return new Future.value();
+  Future<void> shutdown() async {
+    if (_isShutdown) return;
     _isShutdown = true;
-    return _connection.shutdown();
+    if (_connection != null) await _connection.shutdown();
   }
 
   /// Terminates this channel.
   ///
   /// RPCs already in progress will be terminated. No further RPCs can be made
   /// on this channel.
-  Future<Null> terminate() {
+  Future<void> terminate() async {
     _isShutdown = true;
-    return _connection.terminate();
+    if (_connection != null) await _connection.terminate();
   }
 
   /// Returns a connection to this [Channel]'s RPC endpoint.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: grpc
 description: Dart implementation of gRPC.
-version: 0.6.7
+version: 0.6.8
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/grpc-dart
 


### PR DESCRIPTION
If channel is not open calling `terminate()` or `shutdown` triggered Error:

```
Unhandled exception:
NoSuchMethodError: The method 'shutdown' was called on null.
Receiver: null
Tried calling: shutdown()
#0      Object.noSuchMethod (dart:core/runtime/libobject_patch.dart:46:5)
#1      ClientChannel.shutdown (package:grpc/src/client/channel.dart:50:24)
```