### PR TITLE
Sync internal repo changes.

### DIFF
--- a/example/googleapis/bin/logging.dart
+++ b/example/googleapis/bin/logging.dart
@@ -23,7 +23,7 @@ import 'package:googleapis/src/generated/google/logging/type/log_severity.pb.dar
 import 'package:googleapis/src/generated/google/logging/v2/log_entry.pb.dart';
 import 'package:googleapis/src/generated/google/logging/v2/logging.pbgrpc.dart';
 
-Future<Null> main() async {
+Future<void> main() async {
   final serviceAccountFile = new File('logging-service-account.json');
   if (!serviceAccountFile.existsSync()) {
     print('File logging-service-account.json not found. Please follow the '

--- a/example/helloworld/bin/client.dart
+++ b/example/helloworld/bin/client.dart
@@ -21,7 +21,7 @@ import 'package:grpc/grpc.dart';
 import 'package:helloworld/src/generated/helloworld.pb.dart';
 import 'package:helloworld/src/generated/helloworld.pbgrpc.dart';
 
-Future<Null> main(List<String> args) async {
+Future<void> main(List<String> args) async {
   final channel = new ClientChannel('localhost',
       port: 50051,
       options: const ChannelOptions(

--- a/example/helloworld/bin/server.dart
+++ b/example/helloworld/bin/server.dart
@@ -28,7 +28,7 @@ class GreeterService extends GreeterServiceBase {
   }
 }
 
-Future<Null> main(List<String> args) async {
+Future<void> main(List<String> args) async {
   final server = new Server([new GreeterService()]);
   await server.serve(port: 50051);
   print('Server listening on port ${server.port}...');

--- a/example/metadata/lib/src/client.dart
+++ b/example/metadata/lib/src/client.dart
@@ -23,7 +23,7 @@ class Client {
   ClientChannel channel;
   MetadataClient stub;
 
-  Future<Null> main(List<String> args) async {
+  Future<void> main(List<String> args) async {
     channel = new ClientChannel('127.0.0.1',
         port: 8080,
         options: const ChannelOptions(
@@ -42,7 +42,7 @@ class Client {
   ///
   /// Send custom metadata with a RPC, and print out the received response and
   /// metadata.
-  Future<Null> runEcho() async {
+  Future<void> runEcho() async {
     final request = new Record()..value = 'Kaj';
     final call = stub.echo(request,
         options: new CallOptions(metadata: {'peer': 'Verner'}));
@@ -61,7 +61,7 @@ class Client {
   /// Same as the echo demo, but demonstrating per-client custom metadata, as
   /// well as a per-call metadata. The server will delay the response for the
   /// requested duration, during which the client will cancel the RPC.
-  Future<Null> runEchoDelayCancel() async {
+  Future<void> runEchoDelayCancel() async {
     final stubWithCustomOptions = new MetadataClient(channel,
         options: new CallOptions(metadata: {'peer': 'Verner'}));
     final request = new Record()..value = 'Kaj';
@@ -87,7 +87,7 @@ class Client {
   ///
   /// Makes a bi-directional RPC, sends 4 requests, and cancels the RPC after
   /// receiving 3 responses.
-  Future<Null> runAddOneCancel() async {
+  Future<void> runAddOneCancel() async {
     final numbers = new StreamController<int>();
     final call =
         stub.addOne(numbers.stream.map((value) => new Number()..value = value));
@@ -111,7 +111,7 @@ class Client {
   ///
   /// Call an RPC that returns a stream of Fibonacci numbers. Cancel the call
   /// after receiving more than 5 responses.
-  Future<Null> runFibonacciCancel() async {
+  Future<void> runFibonacciCancel() async {
     final call = stub.fibonacci(new Empty());
     int count = 0;
     try {
@@ -132,7 +132,7 @@ class Client {
   ///
   /// Call an RPC that returns a stream of Fibonacci numbers, and specify an RPC
   /// timeout of 2 seconds.
-  Future<Null> runFibonacciTimeout() async {
+  Future<void> runFibonacciTimeout() async {
     final call = stub.fibonacci(new Empty(),
         options: new CallOptions(timeout: new Duration(seconds: 2)));
     int count = 0;

--- a/example/metadata/lib/src/server.dart
+++ b/example/metadata/lib/src/server.dart
@@ -76,7 +76,7 @@ class MetadataService extends MetadataServiceBase {
 }
 
 class Server {
-  Future<Null> main(List<String> args) async {
+  Future<void> main(List<String> args) async {
     final server = new grpc.Server([new MetadataService()]);
     await server.serve(port: 8080);
     print('Server listening on port ${server.port}...');

--- a/example/route_guide/lib/src/client.dart
+++ b/example/route_guide/lib/src/client.dart
@@ -26,7 +26,7 @@ class Client {
   ClientChannel channel;
   RouteGuideClient stub;
 
-  Future<Null> main(List<String> args) async {
+  Future<void> main(List<String> args) async {
     channel = new ClientChannel('127.0.0.1',
         port: 8080,
         options: const ChannelOptions(
@@ -57,7 +57,7 @@ class Client {
 
   /// Run the getFeature demo. Calls getFeature with a point known to have a
   /// feature and a point known not to have a feature.
-  Future<Null> runGetFeature() async {
+  Future<void> runGetFeature() async {
     final point1 = new Point()
       ..latitude = 409146138
       ..longitude = -746188906;
@@ -72,7 +72,7 @@ class Client {
   /// Run the listFeatures demo. Calls listFeatures with a rectangle containing
   /// all of the features in the pre-generated database. Prints each response as
   /// it comes in.
-  Future<Null> runListFeatures() async {
+  Future<void> runListFeatures() async {
     final lo = new Point()
       ..latitude = 400000000
       ..longitude = -750000000;
@@ -92,7 +92,7 @@ class Client {
   /// Run the recordRoute demo. Sends several randomly chosen points from the
   /// pre-generated feature database with a variable delay in between. Prints
   /// the statistics when they are sent from the server.
-  Future<Null> runRecordRoute() async {
+  Future<void> runRecordRoute() async {
     Stream<Point> generateRoute(int count) async* {
       final random = new Random();
 
@@ -116,7 +116,7 @@ class Client {
 
   /// Run the routeChat demo. Send some chat messages, and print any chat
   /// messages that are sent from the server.
-  Future<Null> runRouteChat() async {
+  Future<void> runRouteChat() async {
     RouteNote createNote(String message, int latitude, int longitude) {
       final location = new Point()
         ..latitude = latitude

--- a/example/route_guide/lib/src/server.dart
+++ b/example/route_guide/lib/src/server.dart
@@ -142,7 +142,7 @@ class RouteGuideService extends RouteGuideServiceBase {
 }
 
 class Server {
-  Future<Null> main(List<String> args) async {
+  Future<void> main(List<String> args) async {
     final server = new grpc.Server([new RouteGuideService()]);
     await server.serve(port: 8080);
     print('Server listening on port ${server.port}...');

--- a/interop/bin/server.dart
+++ b/interop/bin/server.dart
@@ -116,7 +116,7 @@ class TestService extends TestServiceBase {
   }
 }
 
-Future<Null> main(List<String> args) async {
+Future<void> main(List<String> args) async {
   final argumentParser = new ArgParser();
   argumentParser.addOption('port', defaultsTo: '8080');
   argumentParser.addOption('use_tls', defaultsTo: 'false');

--- a/interop/lib/src/client.dart
+++ b/interop/lib/src/client.dart
@@ -88,7 +88,7 @@ class Tester {
     return true;
   }
 
-  Future<Null> runTest() async {
+  Future<void> runTest() async {
     ChannelCredentials credentials;
     if (_useTls) {
       List<int> trustedRoot;
@@ -110,7 +110,7 @@ class Tester {
     await channel.shutdown();
   }
 
-  Future<Null> runTestCase() async {
+  Future<void> runTestCase() async {
     switch (testCase) {
       case 'empty_unary':
         return emptyUnary();
@@ -174,7 +174,7 @@ class Tester {
   /// Client asserts:
   /// * call was successful
   /// * response is non-null
-  Future<Null> emptyUnary() async {
+  Future<void> emptyUnary() async {
     final response = await client.emptyCall(new Empty());
     if (response == null) throw 'Expected non-null response.';
     if (response is! Empty) throw 'Expected Empty response.';
@@ -202,7 +202,7 @@ class Tester {
   /// Client asserts:
   /// * Both calls were successful
   /// * The payload body of both responses is the same.
-  Future<Null> cacheableUnary() async {
+  Future<void> cacheableUnary() async {
     throw 'Not implemented';
   }
 
@@ -223,7 +223,7 @@ class Tester {
   /// * response payload body is 314159 bytes in size
   /// * clients are free to assert that the response payload body contents are
   ///   zero and comparing the entire response message against a golden response
-  Future<Null> largeUnary() async {
+  Future<void> largeUnary() async {
     final payload = new Payload()..body = new Uint8List(271828);
     final request = new SimpleRequest()
       ..responseSize = 314159
@@ -282,7 +282,7 @@ class Tester {
   /// * Clients are free to assert that the response payload body contents are
   ///   zeros and comparing the entire response message against a golden
   ///   response.
-  Future<Null> clientCompressedUnary() async {
+  Future<void> clientCompressedUnary() async {
     throw 'Not implemented';
   }
 
@@ -326,7 +326,7 @@ class Tester {
   /// * response payload body is 314159 bytes in size in both cases.
   /// * clients are free to assert that the response payload body contents are
   ///   zero and comparing the entire response message against a golden response
-  Future<Null> serverCompressedUnary() async {
+  Future<void> serverCompressedUnary() async {
     throw 'Not implemented';
   }
 
@@ -363,7 +363,7 @@ class Tester {
   /// Client asserts:
   /// * call was successful
   /// * response aggregated_payload_size is 74922
-  Future<Null> clientStreaming() async {
+  Future<void> clientStreaming() async {
     StreamingInputCallRequest createRequest(int bytes) {
       final request = new StreamingInputCallRequest()..payload = new Payload();
       request.payload.body = new Uint8List(bytes);
@@ -428,7 +428,7 @@ class Tester {
   /// * First call fails with `INVALID_ARGUMENT`.
   /// * Next calls succeeds.
   /// * Response aggregated payload size is 73086.
-  Future<Null> clientCompressedStreaming() async {
+  Future<void> clientCompressedStreaming() async {
     throw 'Not implemented';
   }
 
@@ -457,7 +457,7 @@ class Tester {
   /// * response payload bodies are sized (in order): 31415, 9, 2653, 58979
   /// * clients are free to assert that the response payload body contents are
   ///   zero and comparing the entire response messages against golden responses
-  Future<Null> serverStreaming() async {
+  Future<void> serverStreaming() async {
     final expectedResponses = [31415, 9, 2653, 58979];
 
     final request = new StreamingOutputCallRequest()
@@ -515,7 +515,7 @@ class Tester {
   /// * response payload bodies are sized (in order): 31415, 92653
   /// * clients are free to assert that the response payload body contents are
   ///   zero and comparing the entire response messages against golden responses
-  Future<Null> serverCompressedStreaming() async {
+  Future<void> serverCompressedStreaming() async {
     throw 'Not implemented';
   }
 
@@ -566,7 +566,7 @@ class Tester {
   /// * response payload bodies are sized (in order): 31415, 9, 2653, 58979
   /// * clients are free to assert that the response payload body contents are
   ///   zero and comparing the entire response messages against golden responses
-  Future<Null> pingPong() async {
+  Future<void> pingPong() async {
     final requestSizes = [27182, 8, 1828, 45904];
     final expectedResponses = [31415, 9, 2653, 58979];
 
@@ -611,7 +611,7 @@ class Tester {
   /// Client asserts:
   /// * call was successful
   /// * exactly zero responses
-  Future<Null> emptyStream() async {
+  Future<void> emptyStream() async {
     final requests = new StreamController<StreamingOutputCallRequest>();
     final call = client.fullDuplexCall(requests.stream);
     requests.close();
@@ -653,7 +653,7 @@ class Tester {
   /// * response payload body is 314159 bytes in size
   /// * clients are free to assert that the response payload body contents are
   ///   zero and comparing the entire response message against a golden response
-  Future<Null> computeEngineCreds() async {
+  Future<void> computeEngineCreds() async {
     final credentials = new ComputeEngineAuthenticator();
     final clientWithCredentials =
         new TestServiceClient(channel, options: credentials.toCallOptions);
@@ -709,7 +709,7 @@ class Tester {
   /// * response payload body is 314159 bytes in size
   /// * clients are free to assert that the response payload body contents are
   ///   zero and comparing the entire response message against a golden response
-  Future<Null> serviceAccountCreds() async {
+  Future<void> serviceAccountCreds() async {
     throw 'Not implemented';
   }
 
@@ -743,7 +743,7 @@ class Tester {
   /// * response payload body is 314159 bytes in size
   /// * clients are free to assert that the response payload body contents are
   ///   zero and comparing the entire response message against a golden response
-  Future<Null> jwtTokenCreds() async {
+  Future<void> jwtTokenCreds() async {
     final credentials = new JwtServiceAccountAuthenticator(serviceAccountJson);
     final clientWithCredentials =
         new TestServiceClient(channel, options: credentials.toCallOptions);
@@ -798,7 +798,7 @@ class Tester {
   ///   service account key file or GCE credentials was used, client should
   ///   check against the json key file or GCE default service account email.
   /// * received SimpleResponse.oauth_scope is in `--oauth_scope`
-  Future<Null> oauth2AuthToken() async {
+  Future<void> oauth2AuthToken() async {
     final credentials =
         new ServiceAccountAuthenticator(serviceAccountJson, [oauthScope]);
     final clientWithCredentials =
@@ -853,7 +853,7 @@ class Tester {
   /// * received SimpleResponse.username is not empty and is in the json key
   ///   file used by the auth library. The client can optionally check the
   ///   username matches the email address in the key file.
-  Future<Null> perRpcCreds() async {
+  Future<void> perRpcCreds() async {
     final credentials =
         new ServiceAccountAuthenticator(serviceAccountJson, [oauthScope]);
 
@@ -937,7 +937,7 @@ class Tester {
   /// * metadata with key `"x-grpc-test-echo-trailing-bin"` and value `0xababab`
   ///   is received in the trailing metadata for calls in Procedure steps 1 and
   ///   2.
-  Future<Null> customMetadata() async {
+  Future<void> customMetadata() async {
     void validate(Map<String, String> headers, Map<String, String> trailers) {
       if (headers[_headerEchoKey] != _headerEchoData) {
         throw 'Invalid header data received.';
@@ -1002,7 +1002,7 @@ class Tester {
   ///   steps 1 and 2
   /// * received status message is the same as the sent message for both
   ///   Procedure steps 1 and 2
-  Future<Null> statusCodeAndMessage() async {
+  Future<void> statusCodeAndMessage() async {
     final expectedStatus = new GrpcError.custom(2, 'test status message');
     final responseStatus = new EchoStatus()
       ..code = expectedStatus.code
@@ -1043,7 +1043,7 @@ class Tester {
   ///
   /// Client asserts:
   /// * received status code is 12 (UNIMPLEMENTED)
-  Future<Null> unimplementedMethod() async {
+  Future<void> unimplementedMethod() async {
     try {
       await client.unimplementedCall(new Empty());
       throw 'Did not throw.';
@@ -1063,7 +1063,7 @@ class Tester {
   ///
   /// Client asserts:
   /// * received status code is 12 (UNIMPLEMENTED)
-  Future<Null> unimplementedService() async {
+  Future<void> unimplementedService() async {
     try {
       await unimplementedServiceClient.unimplementedCall(new Empty());
       throw 'Did not throw.';
@@ -1083,7 +1083,7 @@ class Tester {
   ///
   /// Client asserts:
   /// * Call completed with status CANCELLED
-  Future<Null> cancelAfterBegin() async {
+  Future<void> cancelAfterBegin() async {
     final requests = new StreamController<StreamingInputCallRequest>();
     final call = client.streamingInputCall(requests.stream);
     scheduleMicrotask(call.cancel);
@@ -1116,7 +1116,7 @@ class Tester {
   ///
   /// Client asserts:
   /// * Call completed with status CANCELLED
-  Future<Null> cancelAfterFirstResponse() async {
+  Future<void> cancelAfterFirstResponse() async {
     final requests = new StreamController<StreamingOutputCallRequest>();
     final call = client.fullDuplexCall(requests.stream);
     final completer = new Completer();
@@ -1167,7 +1167,7 @@ class Tester {
   ///
   /// Client asserts:
   /// * Call completed with status DEADLINE_EXCEEDED.
-  Future<Null> timeoutOnSleepingServer() async {
+  Future<void> timeoutOnSleepingServer() async {
     final requests = new StreamController<StreamingOutputCallRequest>();
     final call = client.fullDuplexCall(requests.stream,
         options: new CallOptions(timeout: new Duration(milliseconds: 1)));

--- a/lib/src/auth/auth.dart
+++ b/lib/src/auth/auth.dart
@@ -29,7 +29,7 @@ abstract class BaseAuthenticator {
   auth.AccessToken _accessToken;
   String _lastUri;
 
-  Future<Null> authenticate(Map<String, String> metadata, String uri) async {
+  Future<void> authenticate(Map<String, String> metadata, String uri) async {
     if (uri == null) {
       throw new GrpcError.unauthenticated(
           'Credentials require secure transport.');
@@ -54,13 +54,13 @@ abstract class BaseAuthenticator {
 
   CallOptions get toCallOptions => new CallOptions(providers: [authenticate]);
 
-  Future<Null> obtainAccessCredentials(String uri);
+  Future<void> obtainAccessCredentials(String uri);
 }
 
 abstract class HttpBasedAuthenticator extends BaseAuthenticator {
-  Future<Null> _call;
+  Future<void> _call;
 
-  Future<Null> obtainAccessCredentials(String uri) {
+  Future<void> obtainAccessCredentials(String uri) {
     if (_call == null) {
       final authClient = new http.Client();
       _call = obtainCredentialsWithClient(authClient, uri).then((credentials) {
@@ -117,7 +117,7 @@ class JwtServiceAccountAuthenticator extends BaseAuthenticator {
 
   String get projectId => _projectId;
 
-  Future<Null> obtainAccessCredentials(String uri) async {
+  Future<void> obtainAccessCredentials(String uri) async {
     _accessToken = _jwtTokenFor(_serviceAccountCredentials, _keyId, uri);
   }
 }

--- a/lib/src/client/call.dart
+++ b/lib/src/client/call.dart
@@ -277,14 +277,14 @@ class ClientCall<Q, R> implements Response {
   Future<Map<String, String>> get trailers => _trailers.future;
 
   @override
-  Future<Null> cancel() {
+  Future<void> cancel() {
     if (!_responses.isClosed) {
       _responses.addError(new GrpcError.cancelled('Cancelled by client.'));
     }
     return _terminate();
   }
 
-  Future<Null> _terminate() async {
+  Future<void> _terminate() async {
     isCancelled = true;
     _timeoutTimer?.cancel();
     // Don't await _responses.close() here. It'll only complete once the done
@@ -302,7 +302,7 @@ class ClientCall<Q, R> implements Response {
     await Future.wait(futures);
   }
 
-  Future<Null> _safeTerminate() {
+  Future<void> _safeTerminate() {
     return _terminate().catchError((_) {});
   }
 }

--- a/lib/src/client/common.dart
+++ b/lib/src/client/common.dart
@@ -38,7 +38,7 @@ abstract class Response {
 
   /// Cancel this gRPC call. Any remaining request objects will not be sent, and
   /// no further responses will be received.
-  Future<Null> cancel();
+  Future<void> cancel();
 }
 
 /// A gRPC response producing a single value.
@@ -83,5 +83,5 @@ abstract class _ResponseMixin<Q, R> implements Response {
   Future<Map<String, String>> get trailers => _call.trailers;
 
   @override
-  Future<Null> cancel() => _call.cancel();
+  Future<void> cancel() => _call.cancel();
 }

--- a/lib/src/client/connection.dart
+++ b/lib/src/client/connection.dart
@@ -185,7 +185,7 @@ class ClientConnection {
   ///
   /// No further calls may be made on this connection, but existing calls
   /// are allowed to finish.
-  Future<Null> shutdown() async {
+  Future<void> shutdown() async {
     if (_state == ConnectionState.shutdown) return null;
     _setShutdownState();
     await _transport?.finish();
@@ -195,7 +195,7 @@ class ClientConnection {
   ///
   /// All open calls are terminated immediately, and no further calls may be
   /// made on this connection.
-  Future<Null> terminate() async {
+  Future<void> terminate() async {
     _setShutdownState();
     await _transport?.terminate();
   }

--- a/lib/src/client/options.dart
+++ b/lib/src/client/options.dart
@@ -115,7 +115,7 @@ class ChannelOptions {
 /// by previous metadata providers) and the [uri] that is being called, and is
 /// expected to modify the map before returning or before completing the
 /// returned [Future].
-typedef FutureOr<Null> MetadataProvider(
+typedef FutureOr<void> MetadataProvider(
     Map<String, String> metadata, String uri);
 
 /// Runtime options for an RPC.

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -83,7 +83,7 @@ class Server {
 
   Service lookupService(String service) => _services[service];
 
-  Future<Null> serve(
+  Future<void> serve(
       {dynamic address, int port, ServerTlsCredentials security}) async {
     // TODO(dart-lang/grpc-dart#9): Handle HTTP/1.1 upgrade to h2c, if allowed.
     Stream<Socket> server;
@@ -117,7 +117,7 @@ class Server {
     new ServerHandler(lookupService, stream, _interceptors).handle();
   }
 
-  Future<Null> shutdown() async {
+  Future<void> shutdown() async {
     final done = _connections.map((connection) => connection.finish()).toList();
     if (_insecureServer != null) {
       done.add(_insecureServer.close());

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -312,7 +312,7 @@ void main() {
     );
   });
 
-  Future<Null> makeUnaryCall() async {
+  Future<void> makeUnaryCall() async {
     void handleRequest(StreamMessage message) {
       harness
         ..sendResponseHeader()

--- a/test/src/client_utils.dart
+++ b/test/src/client_utils.dart
@@ -158,7 +158,7 @@ class ClientHarness {
     handler(false);
   }
 
-  Future<Null> runTest(
+  Future<void> runTest(
       {Future clientCall,
       dynamic expectedResult,
       String expectedPath,
@@ -192,7 +192,7 @@ class ClientHarness {
     await clientSubscription.cancel();
   }
 
-  Future<Null> expectThrows(Future future, dynamic exception) async {
+  Future<void> expectThrows(Future future, dynamic exception) async {
     try {
       await future;
       fail('Did not throw');
@@ -201,7 +201,7 @@ class ClientHarness {
     }
   }
 
-  Future<Null> runFailureTest(
+  Future<void> runFailureTest(
       {Future clientCall,
       dynamic expectedException,
       String expectedPath,


### PR DESCRIPTION
Replace usage of `Future<Null>` with `Future<void>`.

This is a large-ish but trivial change. Using `Future<void>` is preferred to `Future<Null>`.

In addition, the `FutureOr<Null>` typedef for MetadataProviders actually breaks when defining a function that returns `void`. Since `FutureOr<T>` functions can return `Future<T>` or `T`, a provider that doesn't return a future would have to explicitly return `null`. This change should allow metadata provider functions to return `void` and `Future<void>`.