### PR TITLE
Minor changes to fix some major issues on mobile when using gRPC.

### DIFF
--- a/lib/src/client/call.dart
+++ b/lib/src/client/call.dart
@@ -198,7 +198,7 @@ class ClientCall<Q, R> implements Response {
       }
       _responses.onPause = _responseSubscription.pause;
       _responses.onResume = _responseSubscription.resume;
-      _responses.onCancel = _responseSubscription.cancel;
+      _responses.onCancel = _safeTerminate;
     }
   }
 

--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -90,7 +90,8 @@ class Http2ClientConnection implements connection.ClientConnection {
           onBadCertificate: _validateBadCertificate);
     }
 
-    final connection = ClientTransportConnection.viaSocket(socket);
+    final incoming = socket.handleError((_) => _abandonConnection());
+    final connection = ClientTransportConnection.viaStreams(incoming, socket);
     socket.done.then((_) => _abandonConnection());
 
     // Give the settings settings-frame a bit of time to arrive.
@@ -265,7 +266,7 @@ class Http2ClientConnection implements connection.ClientConnection {
     _cancelTimer();
     _transportConnection = null;
 
-    if (_state == ConnectionState.idle && _state == ConnectionState.shutdown) {
+    if (_state == ConnectionState.idle || _state == ConnectionState.shutdown) {
       // All good.
       return;
     }


### PR DESCRIPTION
* Fixes bug when a ResponseStream is cancelled the underlying HTTP/2 stream is not disconnected so the transport never goes inactive/idle.
* ~~Add connectTimeout to socket connections.~~
* Fixes bug where connect state is mismanaged on socket error.