### PR TITLE
Improve interfaces

### DIFF
--- a/example/grpc-web/web/main.dart
+++ b/example/grpc-web/web/main.dart
@@ -19,8 +19,7 @@ import 'package:grpc_web/app.dart';
 import 'package:grpc_web/src/generated/echo.pbgrpc.dart';
 
 void main() {
-  final channel = new GrpcWebClientChannel.xhr('http://localhost',
-      port: 8080);
+  final channel = new GrpcWebClientChannel.xhr(Uri.parse('http://localhost:8080'));
   final service = EchoServiceClient(channel);
   final app = EchoApp(service);
 

--- a/interop/lib/src/client.dart
+++ b/interop/lib/src/client.dart
@@ -95,7 +95,7 @@ class Tester {
       if (_useTestCA) {
         trustedRoot = new File('ca.pem').readAsBytesSync();
       }
-      credentials = new Http2ChannelCredentials.secure(
+      credentials = new ChannelCredentials.secure(
           certificates: trustedRoot, authority: serverHostOverride);
     } else {
       credentials = const ChannelCredentials.insecure();
@@ -472,8 +472,7 @@ class Tester {
         responses.map((response) => response.payload.body.length).toList();
 
     if (!new ListEquality().equals(responseLengths, expectedResponses)) {
-      throw 'Incorrect response lengths received (${responseLengths.join(
-          ', ')} != ${expectedResponses.join(', ')})';
+      throw 'Incorrect response lengths received (${responseLengths.join(', ')} != ${expectedResponses.join(', ')})';
     }
   }
 
@@ -586,8 +585,7 @@ class Tester {
     requests.add(index);
     await for (final response in responses) {
       if (index >= expectedResponses.length) {
-        throw 'Received too many responses. $index > ${expectedResponses
-            .length}.';
+        throw 'Received too many responses. $index > ${expectedResponses.length}.';
       }
       if (response.payload.body.length != expectedResponses[index]) {
         throw 'Response mismatch for response $index: '

--- a/lib/grpc.dart
+++ b/lib/grpc.dart
@@ -32,14 +32,15 @@ export 'src/client/options.dart'
         defaultIdleTimeout,
         BackoffStrategy,
         defaultBackoffStrategy,
-        ChannelCredentials,
-        ChannelOptions,
         MetadataProvider,
         CallOptions;
 
-// TODO(sigurdm): Get rid of Http2ChannelCredentials.
 export 'src/client/transport/http2_credentials.dart'
-    show BadCertificateHandler, allowBadCertificates, Http2ChannelCredentials;
+    show
+        BadCertificateHandler,
+        allowBadCertificates,
+        ChannelCredentials,
+        ChannelOptions;
 
 export 'src/server/call.dart' show ServiceCall;
 export 'src/server/handler.dart' show ServerHandler;

--- a/lib/grpc_web.dart
+++ b/lib/grpc_web.dart
@@ -31,7 +31,6 @@ export 'src/client/options.dart'
         defaultIdleTimeout,
         BackoffStrategy,
         defaultBackoffStrategy,
-        ChannelCredentials,
         ChannelOptions,
         MetadataProvider,
         CallOptions;

--- a/lib/src/client/channel.dart
+++ b/lib/src/client/channel.dart
@@ -23,10 +23,6 @@ import 'method.dart';
 import 'options.dart';
 
 /// A channel to a virtual RPC endpoint.
-///
-/// For each RPC, the channel picks a [ClientConnection] to dispatch the call.
-/// RPCs on the same channel may be sent to different connections, depending on
-/// load balancing settings.
 abstract class ClientChannel {
   /// Shuts down this channel.
   ///
@@ -45,6 +41,7 @@ abstract class ClientChannel {
       ClientMethod<Q, R> method, Stream<Q> requests, CallOptions options);
 }
 
+/// Auxiliary base class implementing much of ClientChannel.
 abstract class ClientChannelBase implements ClientChannel {
   // TODO(jakobr): Multiple connections, load balancing.
   ClientConnection _connection;

--- a/lib/src/client/http2_channel.dart
+++ b/lib/src/client/http2_channel.dart
@@ -14,21 +14,30 @@
 // limitations under the License.
 
 import 'dart:async';
-import 'package:meta/meta.dart';
 
-import 'channel.dart' as channel;
-import 'options.dart';
+import 'channel.dart';
+import 'connection.dart';
+import 'transport/http2_credentials.dart';
 import 'transport/http2_transport.dart';
 import 'transport/transport.dart';
 
-@visibleForTesting
-Future<Transport> connectTransport(
-    String host, int port, ChannelOptions options) async {
-  return Http2Transport(host, port, options)..connect();
-}
+class ClientChannel extends ClientChannelBase {
+  final String host;
+  final int port;
+  final ChannelOptions options;
 
-class ClientChannel extends channel.ClientChannel {
-  ClientChannel(String host,
-      {int port = 443, ChannelOptions options = const ChannelOptions()})
-      : super(host, connectTransport, port: port, options: options);
+  ClientChannel(this.host,
+      {this.port = 443, this.options = const ChannelOptions()})
+      : super();
+
+  Future<Transport> _connectTransport() async {
+    final result = Http2Transport(host, port, options.credentials);
+    await result.connect();
+    return result;
+  }
+
+  @override
+  ClientConnection createConnection() {
+    return ClientConnection(options, _connectTransport);
+  }
 }

--- a/lib/src/client/http2_channel.dart
+++ b/lib/src/client/http2_channel.dart
@@ -21,6 +21,11 @@ import 'transport/http2_credentials.dart';
 import 'transport/http2_transport.dart';
 import 'transport/transport.dart';
 
+/// A channel to a virtual gRPC endpoint.
+///
+/// For each RPC, the channel picks a [ClientConnection] to dispatch the call.
+/// RPCs on the same channel may be sent to different connections, depending on
+/// load balancing settings.
 class ClientChannel extends ClientChannelBase {
   final String host;
   final int port;

--- a/lib/src/client/method.dart
+++ b/lib/src/client/method.dart
@@ -21,3 +21,11 @@ class ClientMethod<Q, R> {
 
   ClientMethod(this.path, this.requestSerializer, this.responseDeserializer);
 }
+
+// TODO(sigurdm): Find out why we do this.
+String audiencePath(ClientMethod method) {
+  final lastSlashPos = method.path.lastIndexOf('/');
+  return lastSlashPos == -1
+      ? method.path
+      : method.path.substring(0, lastSlashPos);
+}

--- a/lib/src/client/options.dart
+++ b/lib/src/client/options.dart
@@ -16,8 +16,6 @@
 import 'dart:async';
 import 'dart:math';
 
-import 'package:meta/meta.dart';
-
 const defaultIdleTimeout = const Duration(minutes: 5);
 
 typedef Duration BackoffStrategy(Duration lastBackoff);
@@ -36,29 +34,15 @@ Duration defaultBackoffStrategy(Duration lastBackoff) {
   return nextBackoff < _maxBackoff ? nextBackoff : _maxBackoff;
 }
 
-/// Options controlling TLS security settings on a [ClientChannel].
-class ChannelCredentials {
-  final bool isSecure;
-  final String authority;
-
-  @visibleForOverriding
-  const ChannelCredentials(this.isSecure, this.authority);
-
-  /// Disable TLS. RPCs are sent in clear text.
-  const ChannelCredentials.insecure() : this(false, null);
-}
-
 /// Options controlling how connections are made on a [ClientChannel].
 class ChannelOptions {
-  final ChannelCredentials credentials;
   final Duration idleTimeout;
   final BackoffStrategy backoffStrategy;
 
   const ChannelOptions({
-    ChannelCredentials credentials,
     this.idleTimeout = defaultIdleTimeout,
     this.backoffStrategy = defaultBackoffStrategy,
-  }) : this.credentials = credentials ?? const ChannelCredentials.insecure();
+  });
 }
 
 /// Provides per-RPC metadata.

--- a/lib/src/client/transport/http2_credentials.dart
+++ b/lib/src/client/transport/http2_credentials.dart
@@ -30,7 +30,7 @@ typedef bool BadCertificateHandler(X509Certificate certificate, String host);
 /// certificates, etc.
 bool allowBadCertificates(X509Certificate certificate, String host) => true;
 
-class ChannelOptions extends options.ChannelOptions {
+class git ci ChannelOptions extends options.ChannelOptions {
   final ChannelCredentials credentials;
 
   const ChannelOptions({

--- a/lib/src/client/transport/http2_credentials.dart
+++ b/lib/src/client/transport/http2_credentials.dart
@@ -16,7 +16,7 @@
 import 'dart:io';
 
 import '../../shared/security.dart';
-import '../options.dart';
+import '../options.dart' as options;
 
 /// Handler for checking certificates that fail validation. If this handler
 /// returns `true`, the bad certificate is allowed, and the TLS handshake can
@@ -30,23 +30,37 @@ typedef bool BadCertificateHandler(X509Certificate certificate, String host);
 /// certificates, etc.
 bool allowBadCertificates(X509Certificate certificate, String host) => true;
 
-class Http2ChannelCredentials extends ChannelCredentials {
+class ChannelOptions extends options.ChannelOptions {
+  final ChannelCredentials credentials;
+
+  const ChannelOptions({
+    this.credentials,
+    Duration idleTimeout = options.defaultIdleTimeout,
+    options.BackoffStrategy backoffStrategy = options.defaultBackoffStrategy,
+  }) : super(idleTimeout: idleTimeout, backoffStrategy: backoffStrategy);
+}
+
+class ChannelCredentials {
+  final bool isSecure;
+  final String authority;
+
   final List<int> _certificateBytes;
   final String _certificatePassword;
   final BadCertificateHandler onBadCertificate;
 
-  const Http2ChannelCredentials._(bool isSecure, String authority,
-      this._certificateBytes, this._certificatePassword, this.onBadCertificate)
-      : super(isSecure, authority);
+  const ChannelCredentials._(this.isSecure, this.authority,
+      this._certificateBytes, this._certificatePassword, this.onBadCertificate);
 
   /// Enable TLS and optionally specify the [certificates] to trust. If
   /// [certificates] is not provided, the default trust store is used.
-  const Http2ChannelCredentials.secure(
+  const ChannelCredentials.secure(
       {List<int> certificates,
       String password,
       String authority,
       BadCertificateHandler onBadCertificate})
       : this._(true, authority, certificates, password, onBadCertificate);
+
+  const ChannelCredentials.insecure() : this._(false, null, null, null, null);
 
   SecurityContext get securityContext {
     if (!isSecure) return null;

--- a/lib/src/client/transport/transport.dart
+++ b/lib/src/client/transport/transport.dart
@@ -32,6 +32,7 @@ abstract class Transport {
   ActiveStateHandler onActiveStateChanged;
   SocketClosedHandler onSocketClosed;
 
+  String get authority;
   Future<void> connect();
   GrpcTransportStream makeRequest(String path, Duration timeout,
       Map<String, String> metadata, ErrorHandler onRequestFailure);

--- a/lib/src/client/transport/xhr_transport.dart
+++ b/lib/src/client/transport/xhr_transport.dart
@@ -130,12 +130,13 @@ class XhrTransportStream implements GrpcTransportStream {
 }
 
 class XhrTransport extends Transport {
-  final String host;
-  final int port;
+  final Uri uri;
 
   HttpRequest _request;
 
-  XhrTransport(this.host, this.port);
+  XhrTransport(this.uri);
+
+  String get authority => uri.authority;
 
   @override
   Future<void> connect() async {}
@@ -160,7 +161,7 @@ class XhrTransport extends Transport {
   GrpcTransportStream makeRequest(String path, Duration timeout,
       Map<String, String> metadata, ErrorHandler onError) {
     _request = HttpRequest();
-    _request.open('POST', '${host}:${port}${path}');
+    _request.open('POST', '${uri.resolve(path)}');
 
     initializeRequest(_request, metadata);
 

--- a/lib/src/client/transport/xhr_transport.dart
+++ b/lib/src/client/transport/xhr_transport.dart
@@ -161,7 +161,7 @@ class XhrTransport extends Transport {
   GrpcTransportStream makeRequest(String path, Duration timeout,
       Map<String, String> metadata, ErrorHandler onError) {
     _request = HttpRequest();
-    _request.open('POST', '${uri.resolve(path)}');
+    _request.open('POST', uri.resolve(path).toString());
 
     initializeRequest(_request, metadata);
 

--- a/lib/src/client/web_channel.dart
+++ b/lib/src/client/web_channel.dart
@@ -15,20 +15,26 @@
 
 import 'dart:async';
 
-import 'package:grpc/src/client/options.dart';
-import 'package:grpc/src/client/transport/transport.dart';
-import 'package:grpc/src/client/transport/xhr_transport.dart';
-import 'package:meta/meta.dart';
-
 import 'channel.dart';
+import 'connection.dart';
+import 'options.dart';
+import 'transport/transport.dart';
+import 'transport/xhr_transport.dart';
 
-@visibleForTesting
-Future<Transport> connectXhrTransport(
-    String host, int port, ChannelOptions _) async {
-  return XhrTransport(host, port)..connect();
-}
+/// A channel to a grpc-web endpoint.
+class GrpcWebClientChannel extends ClientChannelBase {
+  final Uri uri;
+  ChannelOptions options;
 
-class GrpcWebClientChannel extends ClientChannel {
-  GrpcWebClientChannel.xhr(String host, {int port = 443})
-      : super(host, connectXhrTransport, port: port);
+  GrpcWebClientChannel.xhr(this.uri, {this.options: const ChannelOptions()})
+      : super();
+
+  Future<Transport> _connectXhrTransport() async {
+    return XhrTransport(uri)..connect();
+  }
+
+  @override
+  ClientConnection createConnection() {
+    return ClientConnection(options, _connectXhrTransport);
+  }
 }

--- a/lib/src/client/web_channel.dart
+++ b/lib/src/client/web_channel.dart
@@ -30,7 +30,9 @@ class GrpcWebClientChannel extends ClientChannelBase {
       : super();
 
   Future<Transport> _connectXhrTransport() async {
-    return XhrTransport(uri)..connect();
+    final result = XhrTransport(uri);
+    await result.connect();
+    return result;
   }
 
   @override

--- a/test/client_tests/client_http2_transport_test.dart
+++ b/test/client_tests/client_http2_transport_test.dart
@@ -39,8 +39,8 @@ class MockHttp2Transport extends Http2Transport {
   StreamController<StreamMessage> fromClient;
   StreamController<StreamMessage> toClient;
 
-  MockHttp2Transport(String host, int port, ChannelOptions options)
-      : super(host, port, options);
+  MockHttp2Transport(String host, int port, ChannelCredentials credentials)
+      : super(host, port, credentials);
 
   @override
   Future<void> connect() async {
@@ -71,10 +71,7 @@ class MockHttp2Transport extends Http2Transport {
 
 void main() {
   final MockHttp2Transport transport = new MockHttp2Transport(
-      'host',
-      9999,
-      ChannelOptions(
-          credentials: new Http2ChannelCredentials.secure(authority: 'test')));
+      'host', 9999, ChannelCredentials.secure(authority: 'test'));
 
   setUp(() {
     transport.connect();
@@ -98,7 +95,8 @@ void main() {
           timeout: toTimeoutString(Duration(seconds: 10)));
     };
 
-    transport.makeRequest('test_path', Duration(seconds: 10), metadata);
+    transport.makeRequest('test_path', Duration(seconds: 10), metadata,
+        (error) => fail(error.toString()));
   });
 
   test('Sent data converted to StreamMessages properly', () async {
@@ -107,8 +105,8 @@ void main() {
       "parameter_2": "value_2"
     };
 
-    final stream =
-        transport.makeRequest('test_path', Duration(seconds: 10), metadata);
+    final stream = transport.makeRequest('test_path', Duration(seconds: 10),
+        metadata, (error) => fail(error.toString()));
 
     transport.fromClient.stream.listen((message) {
       final dataMessage = validateDataMessage(message);
@@ -124,8 +122,8 @@ void main() {
       "parameter_2": "value_2"
     };
 
-    final stream =
-        transport.makeRequest('test_path', Duration(seconds: 10), metadata);
+    final stream = transport.makeRequest('test_path', Duration(seconds: 10),
+        metadata, (error) => fail(error.toString()));
 
     stream.incomingMessages.listen((message) {
       expect(message, TypeMatcher<GrpcMetadata>());
@@ -146,8 +144,8 @@ void main() {
       "parameter_2": "value_2"
     };
 
-    final stream =
-        transport.makeRequest('test_path', Duration(seconds: 10), metadata);
+    final stream = transport.makeRequest('test_path', Duration(seconds: 10),
+        metadata, (error) => fail(error.toString()));
     final data = List<int>.filled(10, 0);
     stream.incomingMessages.listen((message) {
       expect(message, TypeMatcher<GrpcData>());

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -16,7 +16,7 @@
 
 import 'dart:io';
 
-import 'package:grpc/grpc.dart';
+import 'package:grpc/src/client/transport/http2_credentials.dart';
 import 'package:test/test.dart';
 
 const isTlsException = const TypeMatcher<TlsException>();
@@ -28,14 +28,14 @@ void main() {
           await new File('test/data/certstore.p12').readAsBytes();
 
       final missingPassword =
-          new Http2ChannelCredentials.secure(certificates: certificates);
+          ChannelCredentials.secure(certificates: certificates);
       expect(() => missingPassword.securityContext, throwsA(isTlsException));
 
-      final wrongPassword = new Http2ChannelCredentials.secure(
+      final wrongPassword = ChannelCredentials.secure(
           certificates: certificates, password: 'wrong');
       expect(() => wrongPassword.securityContext, throwsA(isTlsException));
 
-      final correctPassword = new Http2ChannelCredentials.secure(
+      final correctPassword = ChannelCredentials.secure(
           certificates: certificates, password: 'correct');
       expect(correctPassword.securityContext, isNotNull);
     });


### PR DESCRIPTION
`ChannelCredentials` is now a http2-only-thing

`ClientCall` now asks the `Transport` about the authority.

The Xhr client-channel now takes a Uri.
