### PR TITLE
Making it possible to shutdown a client's _channel

### DIFF
--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -33,4 +33,8 @@ class Client {
       {CallOptions options}) {
     return _channel.createCall(method, requests, _options.mergedWith(options));
   }
+
+  Future<void> close() async {
+    await _channel.shutdown();
+  }
 }


### PR DESCRIPTION
PTAL @sigurdm 

This capability is required to port https://github.com/dart-lang/appengine to grpc.