### PR TITLE
Export less from grpc-web.dart

### DIFF
--- a/lib/grpc.dart
+++ b/lib/grpc.dart
@@ -21,27 +21,21 @@ export 'src/auth/auth.dart'
         ServiceAccountAuthenticator,
         JwtServiceAccountAuthenticator;
 
-export 'src/client/call.dart' show ClientCall;
+export 'src/client/call.dart' show CallOptions, ClientCall, MetadataProvider;
 export 'src/client/client.dart' show Client;
 export 'src/client/common.dart' show Response, ResponseStream, ResponseFuture;
 export 'src/client/connection.dart' show ConnectionState;
 export 'src/client/http2_channel.dart' show ClientChannel;
-export 'src/client/http2_connection.dart' show ClientConnection, Http2ClientConnection;
 export 'src/client/method.dart' show ClientMethod;
 export 'src/client/options.dart'
     show
         defaultIdleTimeout,
         BackoffStrategy,
         defaultBackoffStrategy,
-        MetadataProvider,
-        CallOptions;
+        ChannelOptions;
 
 export 'src/client/transport/http2_credentials.dart'
-    show
-        BadCertificateHandler,
-        allowBadCertificates,
-        ChannelCredentials,
-        ChannelOptions;
+    show BadCertificateHandler, allowBadCertificates, ChannelCredentials;
 
 export 'src/server/call.dart' show ServiceCall;
 export 'src/server/handler.dart' show ServerHandler;

--- a/lib/grpc_web.dart
+++ b/lib/grpc_web.dart
@@ -14,29 +14,12 @@
 // limitations under the License.
 
 export 'src/auth/auth.dart'
-    show
-        BaseAuthenticator,
-        HttpBasedAuthenticator,
-        ComputeEngineAuthenticator,
-        JwtServiceAccountAuthenticator;
+    show HttpBasedAuthenticator, JwtServiceAccountAuthenticator;
 
-export 'src/client/call.dart' show ClientCall;
+export 'src/client/call.dart' show MetadataProvider, CallOptions;
 
-export 'src/client/client.dart' show Client;
 export 'src/client/common.dart' show Response, ResponseStream, ResponseFuture;
-export 'src/client/method.dart' show ClientMethod;
-export 'src/client/options.dart'
-    show
-        defaultIdleTimeout,
-        BackoffStrategy,
-        defaultBackoffStrategy,
-        ChannelOptions,
-        MetadataProvider,
-        CallOptions;
 
-export 'src/client/transport/transport.dart';
 export 'src/client/web_channel.dart' show GrpcWebClientChannel;
 
 export 'src/shared/status.dart' show StatusCode, GrpcError;
-export 'src/shared/streams.dart' show GrpcHttpEncoder, GrpcHttpDecoder;
-export 'src/shared/timeout.dart' show toTimeoutString, fromTimeoutString;

--- a/lib/service_api.dart
+++ b/lib/service_api.dart
@@ -18,10 +18,10 @@
 /// Mainly intended to be imported by generated code.
 library service_api;
 
+export 'src/client/call.dart' show CallOptions;
 export 'src/client/channel.dart' show ClientChannel;
 export 'src/client/client.dart' show Client;
 export 'src/client/common.dart' show ResponseFuture, ResponseStream;
 export 'src/client/method.dart' show ClientMethod;
-export 'src/client/options.dart' show CallOptions;
 export 'src/server/call.dart' show ServiceCall;
 export 'src/server/service.dart' show Service, ServiceMethod;

--- a/lib/src/auth/auth.dart
+++ b/lib/src/auth/auth.dart
@@ -21,7 +21,7 @@ import 'package:googleapis_auth/src/crypto/rsa_sign.dart';
 import 'package:grpc/src/shared/status.dart';
 import 'package:http/http.dart' as http;
 
-import '../client/options.dart';
+import '../client/call.dart';
 
 const _tokenExpirationThreshold = const Duration(seconds: 30);
 

--- a/lib/src/client/call.dart
+++ b/lib/src/client/call.dart
@@ -32,6 +32,55 @@ const _reservedHeaders = const [
   'user-agent',
 ];
 
+/// Provides per-RPC metadata.
+///
+/// Metadata providers will be invoked for every RPC, and can add their own
+/// metadata to the RPC. If the function returns a [Future], the RPC will await
+/// completion of the returned [Future] before transmitting the request.
+///
+/// The metadata provider is given the current [metadata] map (possibly modified
+/// by previous metadata providers) and the [uri] that is being called, and is
+/// expected to modify the map before returning or before completing the
+/// returned [Future].
+typedef FutureOr<void> MetadataProvider(
+    Map<String, String> metadata, String uri);
+
+/// Runtime options for an RPC.
+class CallOptions {
+  final Map<String, String> metadata;
+  final Duration timeout;
+  final List<MetadataProvider> metadataProviders;
+
+  CallOptions._(this.metadata, this.timeout, this.metadataProviders);
+
+  /// Creates a [CallOptions] object.
+  ///
+  /// [CallOptions] can specify static [metadata], set the [timeout], and
+  /// configure per-RPC metadata [providers]. The metadata [providers] are
+  /// invoked in order for every RPC, and can modify the outgoing metadata
+  /// (including metadata provided by previous providers).
+  factory CallOptions(
+      {Map<String, String> metadata,
+        Duration timeout,
+        List<MetadataProvider> providers}) {
+    return new CallOptions._(new Map.unmodifiable(metadata ?? {}), timeout,
+        new List.unmodifiable(providers ?? []));
+  }
+
+  factory CallOptions.from(Iterable<CallOptions> options) =>
+      options.fold(new CallOptions(), (p, o) => p.mergedWith(o));
+
+  CallOptions mergedWith(CallOptions other) {
+    if (other == null) return this;
+    final mergedMetadata = new Map.from(metadata)..addAll(other.metadata);
+    final mergedTimeout = other.timeout ?? timeout;
+    final mergedProviders = new List.from(metadataProviders)
+      ..addAll(other.metadataProviders);
+    return new CallOptions._(new Map.unmodifiable(mergedMetadata),
+        mergedTimeout, new List.unmodifiable(mergedProviders));
+  }
+}
+
 /// An active call to a gRPC endpoint.
 class ClientCall<Q, R> implements Response {
   final ClientMethod<Q, R> _method;

--- a/lib/src/client/call.dart
+++ b/lib/src/client/call.dart
@@ -61,8 +61,8 @@ class CallOptions {
   /// (including metadata provided by previous providers).
   factory CallOptions(
       {Map<String, String> metadata,
-        Duration timeout,
-        List<MetadataProvider> providers}) {
+      Duration timeout,
+      List<MetadataProvider> providers}) {
     return new CallOptions._(new Map.unmodifiable(metadata ?? {}), timeout,
         new List.unmodifiable(providers ?? []));
   }

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -18,7 +18,6 @@ import 'dart:async';
 import 'call.dart';
 import 'channel.dart';
 import 'method.dart';
-import 'options.dart';
 
 /// Base class for client stubs.
 class Client {

--- a/lib/src/client/connection.dart
+++ b/lib/src/client/connection.dart
@@ -61,4 +61,3 @@ abstract class ClientConnection {
   /// made on this connection.
   Future<void> terminate();
 }
-

--- a/lib/src/client/http2_channel.dart
+++ b/lib/src/client/http2_channel.dart
@@ -16,6 +16,7 @@
 import 'channel.dart';
 import 'connection.dart';
 import 'http2_connection.dart' show Http2ClientConnection;
+import 'options.dart';
 import 'transport/http2_credentials.dart';
 
 /// A channel to a virtual gRPC endpoint.

--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -26,6 +26,7 @@ import 'call.dart';
 import 'connection.dart' hide ClientConnection;
 import 'connection.dart' as connection;
 
+import 'options.dart';
 import 'transport/http2_credentials.dart';
 import 'transport/http2_transport.dart';
 import 'transport/transport.dart';

--- a/lib/src/client/options.dart
+++ b/lib/src/client/options.dart
@@ -34,8 +34,8 @@ Duration defaultBackoffStrategy(Duration lastBackoff) {
   return nextBackoff < _maxBackoff ? nextBackoff : _maxBackoff;
 }
 
+/// Options controlling how connections are made on a [ClientChannel].
 class ChannelOptions {
-  /// Options controlling how connections are made on a [ClientChannel].
   final Duration idleTimeout;
   final BackoffStrategy backoffStrategy;
 

--- a/lib/src/client/options.dart
+++ b/lib/src/client/options.dart
@@ -47,4 +47,3 @@ class ChannelOptions {
     this.backoffStrategy = defaultBackoffStrategy,
   });
 }
-

--- a/lib/src/client/transport/http2_credentials.dart
+++ b/lib/src/client/transport/http2_credentials.dart
@@ -30,16 +30,6 @@ typedef bool BadCertificateHandler(X509Certificate certificate, String host);
 /// certificates, etc.
 bool allowBadCertificates(X509Certificate certificate, String host) => true;
 
-class ChannelOptions extends options.ChannelOptions {
-  final ChannelCredentials credentials;
-
-  const ChannelOptions({
-    this.credentials,
-    Duration idleTimeout = options.defaultIdleTimeout,
-    options.BackoffStrategy backoffStrategy = options.defaultBackoffStrategy,
-  }) : super(idleTimeout: idleTimeout, backoffStrategy: backoffStrategy);
-}
-
 class ChannelCredentials {
   final bool isSecure;
   final String authority;

--- a/lib/src/client/transport/xhr_transport.dart
+++ b/lib/src/client/transport/xhr_transport.dart
@@ -190,6 +190,5 @@ class XhrClientConnection extends ClientConnection {
   }
 
   @override
-  Future<void> shutdown() async {
-  }
+  Future<void> shutdown() async {}
 }

--- a/lib/src/client/web_channel.dart
+++ b/lib/src/client/web_channel.dart
@@ -23,10 +23,8 @@ import 'transport/xhr_transport.dart';
 /// A channel to a grpc-web endpoint.
 class GrpcWebClientChannel extends ClientChannelBase {
   final Uri uri;
-  ChannelOptions options;
 
-  GrpcWebClientChannel.xhr(this.uri, {this.options: const ChannelOptions()})
-      : super();
+  GrpcWebClientChannel.xhr(this.uri) : super();
 
   @override
   ClientConnection createConnection() {


### PR DESCRIPTION
The ChannelOptions we have do not make sense for grpc-web. They are now http2-only.

