### PR TITLE
Improve error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* GrpcError now implements Exception to indicate it can be reasonably handled.
+
 ## 2.0.0+1
 
 * Fix imports to ensure grpc-web.dart has no accidental transitive dependencies on dart:io.

--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -71,8 +71,7 @@ class Http2ClientConnection implements connection.ClientConnection {
     var socket = await Socket.connect(host, port);
     if (_state == ConnectionState.shutdown) {
       socket.destroy();
-      // TODO(sigurdm): Throw something nicer...
-      throw 'Shutting down';
+      throw _ShutdownException();
     }
     final securityContext = credentials.securityContext;
     if (securityContext != null) {
@@ -82,8 +81,7 @@ class Http2ClientConnection implements connection.ClientConnection {
           onBadCertificate: _validateBadCertificate);
       if (_state == ConnectionState.shutdown) {
         socket.destroy();
-        // TODO(sigurdm): Throw something nicer...
-        throw 'Shutting down';
+        throw _ShutdownException();
       }
     }
     socket.done.then((_) => _handleSocketClosed());
@@ -273,3 +271,5 @@ class Http2ClientConnection implements connection.ClientConnection {
     return validator(certificate, authority);
   }
 }
+
+class _ShutdownException implements Exception {}

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -85,9 +85,7 @@ class Server {
   Service lookupService(String service) => _services[service];
 
   Future<void> serve(
-      {dynamic address,
-      int port,
-      ServerTlsCredentials security}) async {
+      {dynamic address, int port, ServerTlsCredentials security}) async {
     // TODO(dart-lang/grpc-dart#9): Handle HTTP/1.1 upgrade to h2c, if allowed.
     Stream<Socket> server;
     if (security != null) {
@@ -109,11 +107,8 @@ class Server {
       // timeout.
       connection.incomingStreams.listen((stream) {
         handler = serveStream_(stream);
-      }, onError: (error, stackTrace) {
-        if (error is Error) {
-          Zone.current.handleUncaughtError(error, stackTrace);
-        }
-        // Non-Errors are ignored by the server.
+      }, onError: (error) {
+        print('Connection error: $error');
       }, onDone: () {
         // TODO(sigurdm): This is not correct behavior in the presence of
         // half-closed tcp streams.
@@ -122,11 +117,8 @@ class Server {
         handler?.cancel();
         _connections.remove(connection);
       });
-    }, onError: (error, stackTrace) {
-      if (error is Error) {
-        Zone.current.handleUncaughtError(error, stackTrace);
-      }
-      // Non-Errors are ignored by the server.
+    }, onError: (error) {
+      print('Socket error: $error');
     });
   }
 

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -85,7 +85,10 @@ class Server {
   Service lookupService(String service) => _services[service];
 
   Future<void> serve(
-      {dynamic address, int port, ServerTlsCredentials security}) async {
+      {dynamic address,
+      int port,
+      ServerTlsCredentials security,
+      void Function(String message) logError = print}) async {
     // TODO(dart-lang/grpc-dart#9): Handle HTTP/1.1 upgrade to h2c, if allowed.
     Stream<Socket> server;
     if (security != null) {
@@ -108,7 +111,7 @@ class Server {
       connection.incomingStreams.listen((stream) {
         handler = serveStream_(stream);
       }, onError: (error) {
-        print('Connection error: $error');
+        logError('Connection error: $error');
       }, onDone: () {
         // TODO(sigurdm): This is not correct behavior in the presence of
         // half-closed tcp streams.
@@ -118,7 +121,7 @@ class Server {
         _connections.remove(connection);
       });
     }, onError: (error) {
-      print('Socket error: $error');
+      logError('Socket error: $error');
     });
   }
 

--- a/lib/src/shared/message.dart
+++ b/lib/src/shared/message.dart
@@ -41,7 +41,7 @@ class GrpcMessageSink extends Sink<GrpcMessage> {
   @override
   void add(GrpcMessage data) {
     if (message != null) {
-      throw 'Too many messages received!';
+      throw StateError('Too many messages received!');
     }
     message = data;
   }
@@ -49,7 +49,7 @@ class GrpcMessageSink extends Sink<GrpcMessage> {
   @override
   void close() {
     if (message == null) {
-      throw 'No messages received!';
+      throw StateError('No messages received!');
     }
   }
 }

--- a/lib/src/shared/status.dart
+++ b/lib/src/shared/status.dart
@@ -117,7 +117,7 @@ class StatusCode {
   static const unauthenticated = 16;
 }
 
-class GrpcError {
+class GrpcError implements Exception {
   final int code;
   final String message;
 
@@ -214,6 +214,7 @@ class GrpcError {
 
   /// Internal errors. Means some invariants expected by underlying system has
   /// been broken. If you see one of these errors, something is very broken.
+  // TODO(sigurdm): This should probably not be an [Exception].
   GrpcError.internal([this.message]) : code = StatusCode.internal;
 
   /// The service is currently unavailable.  This is a most likely a transient

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: grpc
 description: Dart implementation of gRPC, a high performance, open-source universal RPC framework.
 
-version: 2.0.0+1
+version: 2.0.1
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/grpc-dart


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-dart/issues/196
1) Let GrpcError implement exception

As the user is (usually) expected to catch these they should implement
Exception.
There is a bigger clean-up in splitting off the GrpcError.internal as
that seems to be for invariant violations

2) Convert some thrown strings into exceptions.
