### PR TITLE
Unimplement unimplementedMethod in interop

### DIFF
--- a/interop/bin/server.dart
+++ b/interop/bin/server.dart
@@ -114,8 +114,9 @@ class TestService extends TestServiceBase {
   }
 
   @override
-  Future<Empty> unimplementedCall(ServiceCall call, Empty request) async {
-    return Empty();
+  Future<Empty> unimplementedCall(ServiceCall call, Empty request) {
+    call.sendTrailers(status: StatusCode.unimplemented);
+    return null;
   }
 }
 

--- a/interop/lib/src/client.dart
+++ b/interop/lib/src/client.dart
@@ -19,9 +19,9 @@ import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
 import 'package:grpc/grpc.dart';
-import 'package:interop/src/generated/empty.pb.dart';
-import 'package:interop/src/generated/messages.pb.dart';
-import 'package:interop/src/generated/test.pbgrpc.dart';
+import 'generated/empty.pb.dart';
+import 'generated/messages.pb.dart';
+import 'generated/test.pbgrpc.dart';
 
 const _headerEchoKey = 'x-grpc-test-echo-initial';
 const _headerEchoData = 'test_initial_metadata_value';


### PR DESCRIPTION
This was implemented by accident in https://github.com/grpc/grpc-dart/commit/6c0f61aaf671e601f6833072705dc7ae8aab7751 .

Should fix https://github.com/grpc/grpc/issues/16580