### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
   chrome: stable
 
 # The Chrome addon does not work on windows
-install:
+before_install:
   - if [ $TRAVIS_OS_NAME = windows ]; then choco install googlechrome ; fi
 
 # Run against both the dev and stable channel.


### PR DESCRIPTION
The 'install' shadowed the 'install' from the dart support; causing no `pub get` resulting in tests to not be run.