### PR TITLE
Use host without port as authority when making secure connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.2
+
+* Fix bug introduced in 2.1.1 where the port would be added to the default authority when making a
+  secure connection.
+
 ## 2.1.1
 
 * Fix bug introduced in 2.1.0 where an explicit `authority` would not be used when making a secure 

--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -81,7 +81,11 @@ class Http2ClientConnection implements connection.ClientConnection {
     if (securityContext != null) {
       // Todo(sigurdm): We want to pass supportedProtocols: ['h2']. http://dartbug.com/37950
       socket = await SecureSocket.secure(socket,
-          host: authority,
+          // This is not really the host, but the authority to verify the TLC
+          // connection against.
+          //
+          // We don't use `this.authority` here, as that includes the port.
+          host: options.credentials.authority ?? host,
           context: securityContext,
           onBadCertificate: _validateBadCertificate);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: grpc
 description: Dart implementation of gRPC, a high performance, open-source universal RPC framework.
 
-version: 2.1.1
+version: 2.1.2
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/grpc-dart


### PR DESCRIPTION
Should fix https://github.com/grpc/grpc-dart/issues/219 and https://github.com/grpc/grpc-dart/issues/237