### PR TITLE
Pass service to interceptors

### DIFF
--- a/lib/src/server/handler.dart
+++ b/lib/src/server/handler.dart
@@ -131,7 +131,7 @@ class ServerHandler_ extends ServiceCall {
   Future<GrpcError> _applyInterceptors() async {
     try {
       for (final interceptor in _interceptors) {
-        final error = await interceptor(this, this._descriptor);
+        final error = await interceptor(this, _service, _descriptor);
         if (error != null) {
           return error;
         }

--- a/lib/src/server/interceptor.dart
+++ b/lib/src/server/interceptor.dart
@@ -11,4 +11,4 @@ import 'service.dart';
 /// If the interceptor throws [Exception], [GrpcError.internal] with exception.toString() will be returned.
 /// If the interceptor returns null, the corresponding [ServiceMethod] of [Service] will be called.
 typedef Interceptor = FutureOr<GrpcError> Function(
-    ServiceCall call, ServiceMethod method);
+    ServiceCall call, Service service, ServiceMethod method);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: grpc
 description: Dart implementation of gRPC, a high performance, open-source universal RPC framework.
 
-version: 2.1.3
+version: 2.2.0
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/grpc-dart

--- a/test/server_test.dart
+++ b/test/server_test.dart
@@ -288,7 +288,8 @@ void main() {
         return expectedResponse;
       }
 
-      final Interceptor interceptor = (call, method) {
+      final Interceptor interceptor = (call, service, method) {
+        expect(service, isA<TestService>());
         if (method.name == "Unary") {
           return null;
         }
@@ -305,12 +306,14 @@ void main() {
       }
 
       test('with sync interceptor', () => doTest(interceptor));
-      test('with async interceptor',
-          () => doTest((call, method) async => interceptor(call, method)));
+      test(
+          'with async interceptor',
+          () => doTest((call, service, method) async =>
+              interceptor(call, service, method)));
     });
 
     group('returns error if interceptor blocks request', () {
-      final Interceptor interceptor = (call, method) {
+      final Interceptor interceptor = (call, service, method) {
         if (method.name == "Unary") {
           return GrpcError.unauthenticated('Request is unauthenticated');
         }
@@ -328,12 +331,14 @@ void main() {
       }
 
       test('with sync interceptor', () => doTest(interceptor));
-      test('with async interceptor',
-          () => doTest((call, method) async => interceptor(call, method)));
+      test(
+          'with async interceptor',
+          () => doTest((call, service, method) async =>
+              interceptor(call, service, method)));
     });
 
     group('returns internal error if interceptor throws exception', () {
-      final Interceptor interceptor = (call, method) {
+      final Interceptor interceptor = (call, service, method) {
         throw Exception('Reason is unknown');
       };
 
@@ -348,12 +353,14 @@ void main() {
       }
 
       test('with sync interceptor', () => doTest(interceptor));
-      test('with async interceptor',
-          () => doTest((call, method) async => interceptor(call, method)));
+      test(
+          'with async interceptor',
+          () => doTest((call, service, method) async =>
+              interceptor(call, service, method)));
     });
 
     test("don't fail if interceptor await 2 times", () async {
-      final Interceptor interceptor = (call, method) async {
+      final Interceptor interceptor = (call, service, method) async {
         await Future.value();
         await Future.value();
         throw Exception('Reason is unknown');

--- a/test/src/server_utils.dart
+++ b/test/src/server_utils.dart
@@ -82,12 +82,13 @@ class TestService extends Service {
 class TestInterceptor {
   Interceptor handler;
 
-  FutureOr<GrpcError> call(ServiceCall call, ServiceMethod method) {
+  FutureOr<GrpcError> call(
+      ServiceCall call, Service service, ServiceMethod method) {
     if (handler == null) {
       return null;
     }
 
-    return handler(call, method);
+    return handler(call, service, method);
   }
 }
 


### PR DESCRIPTION
A single `grpc.Server` can have multiple services, so interceptors may need to know which service they're acting on. Just having the method and its name is insufficient.