### PR TITLE
Use tcpNoDelay option for sockets

### DIFF
--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -78,6 +78,8 @@ class Http2ClientConnection implements connection.ClientConnection {
   Future<ClientTransportConnection> connectTransport() async {
     final securityContext = credentials.securityContext;
     Socket socket = await Socket.connect(host, port);
+    // Don't wait for io buffers to fill up before sending requests.
+    socket.setOption(SocketOption.tcpNoDelay, true);
     if (securityContext != null) {
       // Todo(sigurdm): We want to pass supportedProtocols: ['h2']. http://dartbug.com/37950
       socket = await SecureSocket.secure(socket,

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -105,10 +105,17 @@ class Server {
       server = _secureServer;
     } else {
       _insecureServer = await ServerSocket.bind(
-          address ?? InternetAddress.anyIPv4, port ?? 80, backlog: backlog, shared: shared , v6Only: v6Only);
+        address ?? InternetAddress.anyIPv4,
+        port ?? 80,
+        backlog: backlog,
+        shared: shared,
+        v6Only: v6Only,
+      );
       server = _insecureServer;
     }
     server.listen((socket) {
+      // Don't wait for io buffers to fill up before sending requests.
+      socket.setOption(SocketOption.tcpNoDelay, true);
       final connection = ServerTransportConnection.viaSocket(socket,
           settings: http2ServerSettings);
       _connections.add(connection);


### PR DESCRIPTION
This supersedes/replicates https://github.com/grpc/grpc-dart/pull/275.

Fixes https://github.com/grpc/grpc-dart/issues/249