### PR TITLE
Remove 20ms latency when connect

### DIFF
--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -73,8 +73,6 @@ class Http2ClientConnection implements connection.ClientConnection {
 
   ConnectionState get state => _state;
 
-  static const _estimatedRoundTripTime = const Duration(milliseconds: 20);
-
   Future<ClientTransportConnection> connectTransport() async {
     final securityContext = credentials.securityContext;
     Socket socket = await Socket.connect(host, port);
@@ -94,11 +92,6 @@ class Http2ClientConnection implements connection.ClientConnection {
 
     final connection = ClientTransportConnection.viaSocket(socket);
     socket.done.then((_) => _abandonConnection());
-
-    // Give the settings settings-frame a bit of time to arrive.
-    // TODO(sigurdm): This is a hack. The http2 package should expose a way of
-    // waiting for the settings frame to arrive.
-    await new Future.delayed(_estimatedRoundTripTime);
 
     if (_state == ConnectionState.shutdown) {
       socket.destroy();

--- a/test/client_handles_bad_connections_test.dart
+++ b/test/client_handles_bad_connections_test.dart
@@ -87,7 +87,11 @@ main() async {
     channel.clientConnection.onStateChanged =
         (Http2ClientConnection connection) => states.add(connection.state);
     final testClient = TestClient(channel);
-
+    // This is hack
+    // TODO (hubaxis) setting frame will be received little bit later
+    // we don't want to get delay when we connected. Because of that, need to add option `settingFrameDelay`
+    // By default shouldn't be any delay
+    await testClient.stream(1).toList();
     await Future.wait(<Future>[
       expectLater(testClient.stream(1).toList(), completion([1, 2, 3])),
       expectLater(testClient.stream(1).toList(), completion([1, 2, 3])),


### PR DESCRIPTION
We are using grpc for rpc between microservices. Usually it ~1k requests per second, 20ms delay when connecting incredible long for us