### PR TITLE
Not to fail pending requests, just reschedule it

### DIFF
--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -252,9 +252,8 @@ class Http2ClientConnection implements connection.ClientConnection {
     }
     // TODO(jakobr): Log error.
     _cancelTimer();
-    _pendingCalls.forEach((call) => _failCall(call, error));
-    _pendingCalls.clear();
     _setState(ConnectionState.idle);
+    _connect();
   }
 
   void _handleReconnect() {

--- a/test/client_tests/client_test.dart
+++ b/test/client_tests/client_test.dart
@@ -326,24 +326,6 @@ void main() {
     );
   }
 
-  test('Connection errors are reported', () async {
-    final connectionStates = <ConnectionState>[];
-    harness.connection.connectionError = 'Connection error';
-    harness.connection.onStateChanged = (connection) {
-      final state = connection.state;
-      connectionStates.add(state);
-    };
-
-    final expectedException =
-        GrpcError.unavailable('Error connecting: Connection error');
-
-    await harness.expectThrows(
-        harness.client.unary(dummyValue), expectedException);
-
-    expect(
-        connectionStates, [ConnectionState.connecting, ConnectionState.idle]);
-  });
-
   test('Connections time out if idle', () async {
     final done = Completer();
     final connectionStates = <ConnectionState>[];


### PR DESCRIPTION
Pending calls never started, it doesn't make sense fail it, when connection established all calls will be rescheduled. See https://github.com/grpc/grpc-dart/blob/master/lib/src/client/http2_connection.dart#L129 