### PR TITLE
Change response from a final variable to a var

### DIFF
--- a/example/helloworld/bin/client.dart
+++ b/example/helloworld/bin/client.dart
@@ -30,7 +30,7 @@ Future<void> main(List<String> args) async {
   final name = args.isNotEmpty ? args[0] : 'world';
 
   try {
-    final response = await stub.sayHello(HelloRequest()..name = name);
+    var response = await stub.sayHello(HelloRequest()..name = name);
     print('Greeter client received: ${response.message}');
   } catch (e) {
     print('Caught error: $e');


### PR DESCRIPTION
This better aligns with the gRPC docs, which heavily use this helloworld client.

The docs have you add these two lines:
`
response = await stub.sayHelloAgain(HelloRequest()..name = name);
`
`
print('Greeter client received: ${response.message}');
`

which of course will error with
`
bin/client.dart:35:5: Error: Can't assign to the final variable 'response'.
`
