### PR TITLE
Provide a way to set the connect timeout

### DIFF
--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -77,7 +77,7 @@ class Http2ClientConnection implements connection.ClientConnection {
 
   Future<ClientTransportConnection> connectTransport() async {
     final securityContext = credentials.securityContext;
-    Socket socket = await Socket.connect(host, port);
+    Socket socket = await Socket.connect(host, port, timeout: options.connectTimeout);
     // Don't wait for io buffers to fill up before sending requests.
     socket.setOption(SocketOption.tcpNoDelay, true);
     if (securityContext != null) {

--- a/lib/src/client/options.dart
+++ b/lib/src/client/options.dart
@@ -22,6 +22,7 @@ const defaultIdleTimeout = Duration(minutes: 5);
 /// connection after precisely 1 hour. So we *proactively* refresh our
 /// connection after 50 minutes. This will avoid one failed RPC call.
 const defaultConnectionTimeOut = Duration(minutes: 50);
+const defaultConnectTimeout = Duration(minutes: 2);
 const defaultUserAgent = 'dart-grpc/2.0.0';
 
 typedef Duration BackoffStrategy(Duration lastBackoff);
@@ -50,11 +51,17 @@ class ChannelOptions {
   final BackoffStrategy backoffStrategy;
   final String userAgent;
 
+  /// The maximum allowed time to wait for a connection to be established.
+  /// If [connectTimeout] is longer than the system level timeout duration,
+  /// a timeout may occur sooner than specified in [connectTimeout].
+  final Duration connectTimeout;
+
   const ChannelOptions({
     this.credentials = const ChannelCredentials.secure(),
     this.idleTimeout = defaultIdleTimeout,
     this.userAgent = defaultUserAgent,
     this.backoffStrategy = defaultBackoffStrategy,
     this.connectionTimeout = defaultConnectionTimeOut,
+    this.connectTimeout = defaultConnectTimeout
   });
 }

--- a/test/src/client_utils.dart
+++ b/test/src/client_utils.dart
@@ -51,6 +51,7 @@ class FakeChannelOptions implements ChannelOptions {
   ChannelCredentials credentials = const ChannelCredentials.secure();
   Duration idleTimeout = const Duration(seconds: 1);
   Duration connectionTimeout = const Duration(seconds: 10);
+  Duration connectTimeout = const Duration(seconds: 3);
   String userAgent = 'dart-grpc/1.0.0 test';
   BackoffStrategy backoffStrategy = testBackoff;
 }


### PR DESCRIPTION
The following problem might occur with the current version of grpc-dart:
1. An RPC request is made to a server that is currently unreachable.
2. The server becomes reachable again shortly afterwards.
3. No further RPC request is possible until the default connect timeout which seems to be 2 minutes on Android has elapsed.

The changes of this pull reqeust introduce a new field in the ChannelOptions class, which is used to overwrite the default timeout of the Socket.connect method in the Http2ClientConnection class.
