### PR TITLE
Remove leading slash for gRPC Web

### DIFF
--- a/lib/src/client/transport/xhr_transport.dart
+++ b/lib/src/client/transport/xhr_transport.dart
@@ -134,8 +134,24 @@ class XhrClientConnection extends ClientConnection {
     request.headers['X-Grpc-Web'] = '1';
   }
 
+  // When dart codes are generated from service.proto,
+  // it has a leading slash. Therefore, it's currently not possible to use the
+  // path gets ignored. Hence, remove the leading slash.
+  //
+  // For example, we want to keep '/grpc/' path for gRPC web.
+  //
+  //   Uri.parse('http://localhost:6060/grpc/').resolve('abc/path')
+  //   // http://localhost:6060/grpc/abc/def
+  String _removeLeadingSlash(String path) {
+    if (path.startsWith("/")) {
+      return path.replaceFirst("/", "");
+    }
+    return path;
+  }
+
   @visibleForTesting
-  Request createHttpRequest(String path) => Request('POST', uri.resolve(path));
+  Request createHttpRequest(String path) =>
+      Request('POST', uri.resolve(_removeLeadingSlash(path)));
 
   @visibleForTesting
   Client createClient() => Client();

--- a/lib/src/client/transport/xhr_transport.dart
+++ b/lib/src/client/transport/xhr_transport.dart
@@ -135,8 +135,8 @@ class XhrClientConnection extends ClientConnection {
   }
 
   // When dart codes are generated from service.proto,
-  // it has a leading slash. Therefore, it's currently not possible to use the
-  // path gets ignored. Hence, remove the leading slash.
+  // it has a leading slash. Therefore, the path is ignored as it starts from
+  // the root URL. Hence, we remove the leading slash here.
   //
   // For example, we want to keep '/grpc/' path for gRPC web.
   //

--- a/test/client_tests/client_xhr_transport_test.dart
+++ b/test/client_tests/client_xhr_transport_test.dart
@@ -261,4 +261,11 @@ void main() {
       }
     }, count: expectedMessages.length));
   });
+
+  test('URL path is not ignored when creating a httpRequest', () {
+    final connection =
+        XhrClientConnection(Uri.parse("http://example.com/grpc/"));
+    expect(connection.createHttpRequest("/service/SomeMethod").url.toString(),
+        "http://example.com/grpc/service/SomeMethod");
+  });
 }


### PR DESCRIPTION
so that it can respect the path prefix in the URI.

The current behavior is that the path is completely ignored because
there is a leading slash when the dart code is generated.

For example, '/protos.chat_service.ChatService/CreateStream'.

However, when it gets resolved using `Uri.resolve`,

```dart
void main() {
  final path = '/abc/def';
  final uri = Uri.parse('http://localhost:6060/grpc/');
  print(uri.resolve(path)); // http://localhost:6060/abc/def
  // /grpc/ is gone
}
```

By removing the leading slash when xhr_transport, it can work with path.
Only gRPC web supports path.

## Additional info

The following proto 

```proto
syntax = "proto3";

service Hello {
  rpc SayHello(EmptyMessage) returns (EmptyMessage);
}

message EmptyMessage {}
```

will create a path with the leading slash (/Hello/SayHello)

```dart
class HelloClient extends $grpc.Client {
  static final _$sayHello =
      $grpc.ClientMethod<$0.EmptyMessage, $0.EmptyMessage>(
          '/Hello/SayHello',
          ($0.EmptyMessage value) => value.writeToBuffer(),
          ($core.List<$core.int> value) => $0.EmptyMessage.fromBuffer(value));

  HelloClient($grpc.ClientChannel channel, {$grpc.CallOptions options})
      : super(channel, options: options);

  $grpc.ResponseFuture<$0.EmptyMessage> sayHello($0.EmptyMessage request,
      {$grpc.CallOptions options}) {
    final call = $createCall(_$sayHello, $async.Stream.fromIterable([request]),
        options: options);
    return $grpc.ResponseFuture(call);
  }
}
```

And then we initialize 

```dart
final channel =
  GrpcWebClientChannel.xhr(Uri.parse("https://k8s.kkweon.dev/grpc/"));
```

And this /grpc/ will be ignored at the current version.
The proposed fix is to change /Hello/SayHello -> Hello/SayHello for gRPC web.

And, it works for users who don't have path as well.

## Related Issues

- fixes #258