### PR TITLE
Add timeline logging to grpc client

### DIFF
--- a/lib/grpc.dart
+++ b/lib/grpc.dart
@@ -49,8 +49,7 @@ export 'src/server/service.dart' show ServiceMethod, Service;
 export 'src/shared/message.dart'
     show GrpcMessage, GrpcMetadata, GrpcData, grpcDecompressor;
 
-export 'src/shared/profiler.dart'
-    show enableTimelineLogging, disableTimelineLogging;
+export 'src/shared/profiler.dart';
 
 export 'src/shared/security.dart'
     show supportedAlpnProtocols, createSecurityContext;

--- a/lib/grpc.dart
+++ b/lib/grpc.dart
@@ -49,6 +49,9 @@ export 'src/server/service.dart' show ServiceMethod, Service;
 export 'src/shared/message.dart'
     show GrpcMessage, GrpcMetadata, GrpcData, grpcDecompressor;
 
+export 'src/shared/profiler.dart'
+    show enableTimelineLogging, disableTimelineLogging;
+
 export 'src/shared/security.dart'
     show supportedAlpnProtocols, createSecurityContext;
 export 'src/shared/status.dart' show StatusCode, GrpcError;

--- a/lib/src/client/call.dart
+++ b/lib/src/client/call.dart
@@ -322,12 +322,7 @@ class ClientCall<Q, R> implements Response {
         _responseError(GrpcError.custom(statusCode, message));
       }
     }
-
-    // Both headers and trailers should be received.
-    _timeline?.finish(arguments: {
-      'headers': _headers.future.toString(),
-      'trailers': _trailers.future.toString(),
-    });
+    _timeline?.finish();
     _timeoutTimer?.cancel();
     _responses.close();
     _responseSubscription.cancel();

--- a/lib/src/client/channel.dart
+++ b/lib/src/client/channel.dart
@@ -78,13 +78,8 @@ abstract class ClientChannelBase implements ClientChannel {
   @override
   ClientCall<Q, R> createCall<Q, R>(
       ClientMethod<Q, R> method, Stream<Q> requests, CallOptions options) {
-    var call;
-    if (enableTimelineLogging) {
-      final timeline = TimelineTask(filterKey: 'grpc/client');
-      call = ClientCall(method, requests, options, timeline);
-    } else {
-      call = ClientCall(method, requests, options, null);
-    }
+    final call = ClientCall(method, requests, options,
+        enableTimelineLogging ? TimelineTask(filterKey: 'grpc/client') : null);
     getConnection().then((connection) {
       if (call.isCancelled) return;
       connection.dispatchCall(call);

--- a/lib/src/client/channel.dart
+++ b/lib/src/client/channel.dart
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 import 'dart:async';
+import 'dart:developer';
 
 import '../shared/status.dart';
 
@@ -47,6 +48,8 @@ abstract class ClientChannelBase implements ClientChannel {
 
   bool _isShutdown = false;
 
+  static bool enableTimelineLogging = false;
+
   ClientChannelBase();
 
   @override
@@ -75,7 +78,13 @@ abstract class ClientChannelBase implements ClientChannel {
   @override
   ClientCall<Q, R> createCall<Q, R>(
       ClientMethod<Q, R> method, Stream<Q> requests, CallOptions options) {
-    final call = ClientCall(method, requests, options);
+    var call;
+    if (enableTimelineLogging) {
+      final timeline = TimelineTask(filterKey: 'grpc/client');
+      call = ClientCall(method, requests, options, timeline);
+    } else {
+      call = ClientCall(method, requests, options, null);
+    }
     getConnection().then((connection) {
       if (call.isCancelled) return;
       connection.dispatchCall(call);

--- a/lib/src/shared/profiler.dart
+++ b/lib/src/shared/profiler.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, the gRPC project authors. Please see the AUTHORS file
+// Copyright (c) 2020, the gRPC project authors. Please see the AUTHORS file
 // for details. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,16 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export 'src/auth/auth.dart'
-    show HttpBasedAuthenticator, JwtServiceAccountAuthenticator;
+import '../client/channel.dart';
 
-export 'src/client/call.dart' show MetadataProvider, CallOptions;
+void enableTimelineLogging() {
+  ClientChannelBase.enableTimelineLogging = true;
+}
 
-export 'src/client/common.dart' show Response, ResponseStream, ResponseFuture;
-
-export 'src/client/web_channel.dart' show GrpcWebClientChannel;
-
-export 'src/shared/profiler.dart'
-    show enableTimelineLogging, disableTimelineLogging;
-
-export 'src/shared/status.dart' show StatusCode, GrpcError;
+void disableTimelineLogging() {
+  ClientChannelBase.enableTimelineLogging = false;
+}

--- a/lib/src/shared/profiler.dart
+++ b/lib/src/shared/profiler.dart
@@ -15,10 +15,19 @@
 
 import '../client/channel.dart';
 
+/// Enable logging requests and response for clients.
+///
+/// Logging is disabled by default.
 void enableTimelineLogging() {
   ClientChannelBase.enableTimelineLogging = true;
 }
 
+/// Disbale timeline logging for clients.
 void disableTimelineLogging() {
   ClientChannelBase.enableTimelineLogging = false;
+}
+
+/// Get the current status of timeline logging.
+bool getTimelineLoggingStatus() {
+  return ClientChannelBase.enableTimelineLogging;
 }

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -1,0 +1,366 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library test_helper;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'package:vm_service/vm_service_io.dart';
+import 'package:vm_service/vm_service.dart';
+import 'package:test/test.dart';
+
+typedef IsolateTest = Future<void> Function(
+    VmService service, IsolateRef isolate);
+typedef VMTest = Future<void> Function(VmService service);
+
+/// Will be set to the http address of the VM's service protocol before
+/// any tests are invoked.
+String serviceHttpAddress;
+String serviceWebsocketAddress;
+
+const String _TESTEE_ENV_KEY = 'SERVICE_TEST_TESTEE';
+const Map<String, String> _TESTEE_SPAWN_ENV = {_TESTEE_ENV_KEY: 'true'};
+bool _isTestee() {
+  return Platform.environment.containsKey(_TESTEE_ENV_KEY);
+}
+
+Uri _getTestUri() {
+  if (Platform.script.scheme == 'data') {
+    // If we're using pub to run these tests this value isn't a file URI.
+    // We'll need to parse the actual URI out...
+    final fileRegExp = RegExp(r'file:\/\/\/.*\.dart');
+    final path = fileRegExp.stringMatch(Platform.script.data.contentAsString());
+    if (path == null) {
+      throw 'Unable to determine file path for script!';
+    }
+    return Uri.parse(path);
+  } else {
+    return Platform.script;
+  }
+}
+
+class _ServiceTesteeRunner {
+  Future run(
+      {Function() testeeBefore,
+      Function() testeeConcurrent,
+      bool pause_on_start = false,
+      bool pause_on_exit = false}) async {
+    if (!pause_on_start) {
+      if (testeeBefore != null) {
+        var result = testeeBefore();
+        if (result is Future) {
+          await result;
+        }
+      }
+      print(''); // Print blank line to signal that testeeBefore has run.
+    }
+    if (testeeConcurrent != null) {
+      var result = testeeConcurrent();
+      if (result is Future) {
+        await result;
+      }
+    }
+    if (!pause_on_exit) {
+      // Wait around for the process to be killed.
+      // ignore: unawaited_futures
+      stdin.first.then((_) => exit(0));
+    }
+  }
+}
+
+class _ServiceTesteeLauncher {
+  Process process;
+  List<String> args;
+  bool killedByTester = false;
+
+  _ServiceTesteeLauncher() : args = [_getTestUri().toFilePath()];
+
+  // Spawn the testee process.
+  Future<Process> _spawnProcess(
+    bool pause_on_start,
+    bool pause_on_exit,
+    bool pause_on_unhandled_exceptions,
+    bool testeeControlsServer,
+    bool useAuthToken,
+    List<String> extraArgs,
+  ) {
+    assert(pause_on_start != null);
+    assert(pause_on_exit != null);
+    assert(pause_on_unhandled_exceptions != null);
+    assert(testeeControlsServer != null);
+    assert(useAuthToken != null);
+    return _spawnDartProcess(
+        pause_on_start,
+        pause_on_exit,
+        pause_on_unhandled_exceptions,
+        testeeControlsServer,
+        useAuthToken,
+        extraArgs);
+  }
+
+  Future<Process> _spawnDartProcess(
+      bool pause_on_start,
+      bool pause_on_exit,
+      bool pause_on_unhandled_exceptions,
+      bool testeeControlsServer,
+      bool useAuthToken,
+      List<String> extraArgs) {
+    String dartExecutable = Platform.executable;
+
+    var fullArgs = <String>[
+      '--disable-dart-dev',
+    ];
+    if (pause_on_start) {
+      fullArgs.add('--pause-isolates-on-start');
+    }
+    if (pause_on_exit) {
+      fullArgs.add('--pause-isolates-on-exit');
+    }
+    if (!useAuthToken) {
+      fullArgs.add('--disable-service-auth-codes');
+    }
+    if (pause_on_unhandled_exceptions) {
+      fullArgs.add('--pause-isolates-on-unhandled-exceptions');
+    }
+    fullArgs.add('--profiler');
+    if (extraArgs != null) {
+      fullArgs.addAll(extraArgs);
+    }
+
+    fullArgs.addAll(Platform.executableArguments);
+    if (!testeeControlsServer) {
+      fullArgs.add('--enable-vm-service:0');
+    }
+    fullArgs.addAll(args);
+
+    return _spawnCommon(dartExecutable, fullArgs, <String, String>{});
+  }
+
+  Future<Process> _spawnCommon(String executable, List<String> arguments,
+      Map<String, String> dartEnvironment) {
+    var environment = _TESTEE_SPAWN_ENV;
+    var bashEnvironment = StringBuffer();
+    environment.forEach((k, v) => bashEnvironment.write("$k=$v "));
+    if (dartEnvironment != null) {
+      dartEnvironment.forEach((k, v) {
+        arguments.insert(0, '-D$k=$v');
+      });
+    }
+    print('** Launching $bashEnvironment$executable ${arguments.join(' ')}');
+    return Process.start(executable, arguments, environment: environment);
+  }
+
+  Future<Uri> launch(
+      bool pause_on_start,
+      bool pause_on_exit,
+      bool pause_on_unhandled_exceptions,
+      bool testeeControlsServer,
+      bool useAuthToken,
+      List<String> extraArgs) {
+    return _spawnProcess(
+            pause_on_start,
+            pause_on_exit,
+            pause_on_unhandled_exceptions,
+            testeeControlsServer,
+            useAuthToken,
+            extraArgs)
+        .then((p) {
+      Completer<Uri> completer = Completer<Uri>();
+      process = p;
+      Uri uri;
+      var blank;
+      var first = true;
+      process.stdout
+          .transform(utf8.decoder)
+          .transform(LineSplitter())
+          .listen((line) {
+        const kObservatoryListening = 'Observatory listening on ';
+        if (line.startsWith(kObservatoryListening)) {
+          uri = Uri.parse(line.substring(kObservatoryListening.length));
+        }
+        if (pause_on_start || line == '') {
+          // Received blank line.
+          blank = true;
+        }
+        if ((uri != null) && (blank == true) && (first == true)) {
+          completer.complete(uri);
+          // Stop repeat completions.
+          first = false;
+          print('** Signaled to run test queries on $uri');
+        }
+        print('>testee>out> $line');
+      });
+      process.stderr
+          .transform(utf8.decoder)
+          .transform(LineSplitter())
+          .listen((line) {
+        print('>testee>err> $line');
+      });
+      process.exitCode.then((exitCode) {
+        if ((exitCode != 0) && !killedByTester) {
+          throw "Testee exited with $exitCode";
+        }
+        print("** Process exited");
+      });
+      return completer.future;
+    });
+  }
+
+  void requestExit() {
+    if (process != null) {
+      print('** Killing script');
+      if (process.kill()) {
+        killedByTester = true;
+      }
+    }
+  }
+}
+
+void setupAddresses(Uri serverAddress) {
+  serviceWebsocketAddress =
+      'ws://${serverAddress.authority}${serverAddress.path}ws';
+  serviceHttpAddress = 'http://${serverAddress.authority}${serverAddress.path}';
+}
+
+class _ServiceTesterRunner {
+  Future run(
+      {List<String> mainArgs,
+      List<String> extraArgs,
+      List<VMTest> vmTests,
+      List<IsolateTest> isolateTests,
+      bool pause_on_start = false,
+      bool pause_on_exit = false,
+      bool verbose_vm = false,
+      bool pause_on_unhandled_exceptions = false,
+      bool testeeControlsServer = false,
+      bool useAuthToken = false}) async {
+    var process = _ServiceTesteeLauncher();
+    VmService vm;
+    IsolateRef isolate;
+    setUp(() async {
+      await process
+          .launch(pause_on_start, pause_on_exit, pause_on_unhandled_exceptions,
+              testeeControlsServer, useAuthToken, extraArgs)
+          .then((Uri serverAddress) async {
+        if (mainArgs.contains("--gdb")) {
+          var pid = process.process.pid;
+          var wait = Duration(seconds: 10);
+          print("Testee has pid $pid, waiting $wait before continuing");
+          sleep(wait);
+        }
+        setupAddresses(serverAddress);
+        vm = await vmServiceConnectUri(serviceWebsocketAddress);
+        print('Done loading VM');
+        isolate = await getFirstIsolate(vm);
+      });
+    });
+
+    final name = _getTestUri().pathSegments.last;
+
+    test(
+      name,
+      () async {
+        // Run vm tests.
+        if (vmTests != null) {
+          var testIndex = 1;
+          var totalTests = vmTests.length;
+          for (var t in vmTests) {
+            print('$name [$testIndex/$totalTests]');
+            await t(vm);
+            testIndex++;
+          }
+        }
+
+        // Run isolate tests.
+        if (isolateTests != null) {
+          var testIndex = 1;
+          var totalTests = isolateTests.length;
+          for (var t in isolateTests) {
+            print('$name [$testIndex/$totalTests]');
+            await t(vm, isolate);
+            testIndex++;
+          }
+        }
+      },
+      retry: 0,
+      timeout: Timeout.none,
+    );
+
+    tearDown(() {
+      print('All service tests completed successfully.');
+      process.requestExit();
+    });
+  }
+
+  Future<IsolateRef> getFirstIsolate(VmService service) async {
+    var vm = await service.getVM();
+
+    if (vm.isolates.isNotEmpty) {
+      return vm.isolates.first;
+    }
+    var completer = Completer();
+    StreamSubscription subscription;
+    subscription = service.onIsolateEvent.listen((Event event) async {
+      if (completer == null) {
+        await subscription.cancel();
+        return;
+      }
+      if (event.kind == EventKind.kIsolateRunnable) {
+        vm = await service.getVM();
+        assert(vm.isolates.isNotEmpty);
+        await subscription.cancel();
+        completer.complete(vm.isolates.first);
+        completer = null;
+      }
+    });
+
+    // The isolate may have started before we subscribed.
+    vm = await service.getVM();
+    if (vm.isolates.isNotEmpty) {
+      await subscription.cancel();
+      completer.complete(vm.isolates.first);
+      completer = null;
+    }
+    return await completer.future;
+  }
+}
+
+/// Runs [tests] in sequence, each of which should take an [Isolate] and
+/// return a [Future]. Code for setting up state can run before and/or
+/// concurrently with the tests. Uses [mainArgs] to determine whether
+/// to run tests or testee in this invocation of the script.
+Future<void> runIsolateTests(
+  List<String> mainArgs,
+  List<IsolateTest> tests, {
+  testeeBefore(),
+  testeeConcurrent(),
+  bool pause_on_start = false,
+  bool pause_on_exit = false,
+  bool verbose_vm = false,
+  bool pause_on_unhandled_exceptions = false,
+  bool testeeControlsServer = false,
+  bool useAuthToken = false,
+  List<String> extraArgs,
+}) async {
+  assert(!pause_on_start || testeeBefore == null);
+  if (_isTestee()) {
+    await _ServiceTesteeRunner().run(
+        testeeBefore: testeeBefore,
+        testeeConcurrent: testeeConcurrent,
+        pause_on_start: pause_on_start,
+        pause_on_exit: pause_on_exit);
+  } else {
+    await _ServiceTesterRunner().run(
+        mainArgs: mainArgs,
+        extraArgs: extraArgs,
+        isolateTests: tests,
+        pause_on_start: pause_on_start,
+        pause_on_exit: pause_on_exit,
+        verbose_vm: verbose_vm,
+        pause_on_unhandled_exceptions: pause_on_unhandled_exceptions,
+        testeeControlsServer: testeeControlsServer,
+        useAuthToken: useAuthToken);
+  }
+}

--- a/test/timeline_test.dart
+++ b/test/timeline_test.dart
@@ -1,0 +1,148 @@
+// Copyright (c) 2020, the gRPC project authors. Please see the AUTHORS file
+// for details. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+import 'dart:async';
+
+import 'package:grpc/grpc.dart';
+import 'package:grpc/service_api.dart' as api;
+import 'package:grpc/src/client/channel.dart' hide ClientChannel;
+import 'package:grpc/src/client/connection.dart';
+import 'package:grpc/src/client/http2_connection.dart';
+import 'package:test/test.dart';
+import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service_io.dart';
+
+import 'test_util.dart';
+
+const String path = '/test.TestService/stream';
+
+class TestClient extends Client {
+  static final _$stream = ClientMethod<int, int>(
+      path, (int value) => [value], (List<int> value) => value[0]);
+
+  TestClient(api.ClientChannel channel) : super(channel);
+  ResponseStream<int> stream(int request, {CallOptions options}) {
+    final call =
+        $createCall(_$stream, Stream.fromIterable([request]), options: options);
+    return ResponseStream(call);
+  }
+}
+
+class TestService extends Service {
+  String get $name => 'test.TestService';
+
+  TestService() {
+    $addMethod(ServiceMethod<int, int>('stream', stream, false, true,
+        (List<int> value) => value[0], (int value) => [value]));
+  }
+
+  Stream<int> stream(ServiceCall call, Future request) async* {
+    yield 1;
+    yield 2;
+    yield 3;
+  }
+}
+
+class FixedConnectionClientChannel extends ClientChannelBase {
+  final Http2ClientConnection clientConnection;
+  List<ConnectionState> states = <ConnectionState>[];
+  FixedConnectionClientChannel(this.clientConnection) {
+    clientConnection.onStateChanged = (c) => states.add(c.state);
+  }
+  @override
+  ClientConnection createConnection() => clientConnection;
+}
+
+testee() async {
+  final Server server = Server([TestService()]);
+  await server.serve(address: 'localhost', port: 0);
+
+  enableTimelineLogging();
+  final channel = FixedConnectionClientChannel(Http2ClientConnection(
+    'localhost',
+    server.port,
+    ChannelOptions(credentials: ChannelCredentials.insecure()),
+  ));
+  final testClient = TestClient(channel);
+  await testClient.stream(1).toList();
+  await server.shutdown();
+}
+
+void checkStartEvent(List<Map> events) {
+  final e = events.firstWhere((e) => e['ph'] == 'b');
+  expect(e['args']['method'], isNotNull);
+  expect(e['args']['method'], equals(path));
+}
+
+void checkSendEvent(List<Map> events) {
+  final e = events.firstWhere((e) => e['name'] == 'Request sent');
+  expect(e['args']['metadata'], isNotNull);
+}
+
+void checkWriteEvent(List<Map> events) {
+  final e = events.firstWhere((e) => e['name'] == 'Data sent');
+  expect(e['args']['data'], isNotNull);
+  expect(e['args']['data'], equals('1'));
+}
+
+void checkReceiveEvent(List<Map> events) {
+  events = events.where((e) => e['name'] == 'Data received').toList();
+  expect(events.length, equals(3));
+  int sum = 0;
+  for (final e in events) {
+    // 3 elements are 1, 2 and 3.
+    sum |= 1 << int.parse(e['args']['data']);
+  }
+  expect(sum, equals(14));
+}
+
+void checkReceiveMetaDataEvent(List<Map> events) {
+  events = events.where((e) => e['name'] == 'Metadata received').toList();
+  expect(events.length, equals(2));
+  for (final e in events) {
+    if (e['args']['headers'] != null) {
+      final header = e['args']['headers'];
+      expect(header, contains('status: 200'));
+      expect(header, contains('content-type: application/grpc'));
+    } else {
+      expect(e['args']['trailers'], contains('grpc-status: 0'));
+    }
+  }
+}
+
+void checkFinishEvent(List<Map> events) {
+  final e = events.firstWhere((e) => e['ph'] == 'e');
+  expect(e, isNotNull);
+}
+
+var tests = <IsolateTest>[
+  (VmService service, IsolateRef i) async {
+    final timeline = await service.getVMTimeline();
+    final events = timeline.traceEvents
+        .where((e) => e.json['args']['filterKey'] == 'grpc/client')
+        .map((e) => e.json)
+        .toList();
+    checkStartEvent(events);
+    checkSendEvent(events);
+    checkWriteEvent(events);
+    checkReceiveEvent(events);
+    checkReceiveMetaDataEvent(events);
+    checkFinishEvent(events);
+  },
+];
+
+main([args = const <String>[]]) async => runIsolateTests(args, tests,
+    testeeBefore: testee, extraArgs: ['--timeline_streams=Dart']);


### PR DESCRIPTION
This pr is part of the work that allows Flutter devtool to monitor the content of grpc traffic.

This pr only monitors client side activities.

enableTimelineLogging()/disableTimelineLogging() is used to turn on/off the logging. Note that only rpcs that created after enabling the logging will be recorded.