### PR TITLE
Call to onMetadata handles exceptions

### DIFF
--- a/lib/src/server/handler.dart
+++ b/lib/src/server/handler.dart
@@ -164,8 +164,14 @@ class ServerHandler_ extends ServiceCall {
 
     final error = _onMetadata();
     if (error != null) {
+      if (!_requests.isClosed) {
+        _requests
+          ..addError(error)
+          ..close();
+      }
       _sendError(error);
-      _sinkIncoming();
+      _onDone();
+      _stream.terminate();
       return;
     }
 

--- a/lib/src/server/handler.dart
+++ b/lib/src/server/handler.dart
@@ -131,6 +131,18 @@ class ServerHandler_ extends ServiceCall {
     _startStreamingRequest();
   }
 
+  GrpcError _onMetadata() {
+    try {
+      _service.$onMetadata(this);
+    } on GrpcError catch (error) {
+      return error;
+    } catch (error) {
+      final grpcError = GrpcError.internal(error.toString());
+      return grpcError;
+    }
+    return null;
+  }
+
   Future<GrpcError> _applyInterceptors() async {
     try {
       for (final interceptor in _interceptors) {
@@ -150,7 +162,13 @@ class ServerHandler_ extends ServiceCall {
     _requests = _descriptor.createRequestStream(_incomingSubscription);
     _incomingSubscription.onData(_onDataActive);
 
-    _service.$onMetadata(this);
+    final error = _onMetadata();
+    if (error != null) {
+      _sendError(error);
+      _sinkIncoming();
+      return;
+    }
+
     _responses = _descriptor.handle(this, _requests.stream);
 
     _responseSubscription = _responses.listen(_onResponse,

--- a/test/round_trip_test.dart
+++ b/test/round_trip_test.dart
@@ -98,11 +98,7 @@ main() async {
       ChannelOptions(credentials: ChannelCredentials.insecure()),
     ));
     final testClient = TestClient(channel);
-    await testClient
-        .stream(1)
-        .toList()
-        .catchError((error) => expect(error, isA<GrpcError>()));
-
+    await expectLater(testClient.stream(1).toList(), throwsA(isA<GrpcError>()));
     server.shutdown();
   });
 }

--- a/test/round_trip_test.dart
+++ b/test/round_trip_test.dart
@@ -99,6 +99,6 @@ main() async {
     ));
     final testClient = TestClient(channel);
     await expectLater(testClient.stream(1).toList(), throwsA(isA<GrpcError>()));
-    server.shutdown();
+    await server.shutdown();
   });
 }

--- a/test/round_trip_test.dart
+++ b/test/round_trip_test.dart
@@ -35,6 +35,12 @@ class TestService extends Service {
   }
 }
 
+class TestServiceWithOnMetadataException extends TestService {
+  void $onMetadata(ServiceCall context) {
+    throw Exception('business exception');
+  }
+}
+
 class FixedConnectionClientChannel extends ClientChannelBase {
   final Http2ClientConnection clientConnection;
   List<ConnectionState> states = <ConnectionState>[];
@@ -79,6 +85,24 @@ main() async {
     ));
     final testClient = TestClient(channel);
     expect(await testClient.stream(1).toList(), [1, 2, 3]);
+    server.shutdown();
+  });
+
+  test('exception in onMetadataException', () async {
+    final Server server = Server([TestServiceWithOnMetadataException()]);
+    await server.serve(address: 'localhost', port: 0);
+
+    final channel = FixedConnectionClientChannel(Http2ClientConnection(
+      'localhost',
+      server.port,
+      ChannelOptions(credentials: ChannelCredentials.insecure()),
+    ));
+    final testClient = TestClient(channel);
+    await testClient
+        .stream(1)
+        .toList()
+        .catchError((error) => expect(error, isA<GrpcError>()));
+
     server.shutdown();
   });
 }


### PR DESCRIPTION
This PR solves the issue https://github.com/grpc/grpc-dart/issues/341, where the server will crash when an exception is thrown from the onMetadata method.

It handles the exception in order for the exception to be returned to the client, the request not being processed, yet the server not crashing.

Fixes https://github.com/grpc/grpc-dart/issues/341