### PR TITLE
Ban insecure connections if platform disallows it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1
+
+* Avoid insecure connections if the network policy does not allow it.
+
 ## 2.2.0+1
 
 * Relax `crypto` version dependency constraint from `^2.1.5` to `^2.1.4`.

--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -78,6 +78,9 @@ class Http2ClientConnection implements connection.ClientConnection {
   Future<Socket> _createSocket() async {
     final securityContext = credentials.securityContext;
     if (securityContext == null) {
+      if (!isInsecureConnectionAllowed(host)) {
+        throw StateError("Insecure gRPC is not allowed by platform: $host");
+      }
       return Socket.connect(host, port);
     } else {
       if (options.credentials.authority == null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: grpc
 description: Dart implementation of gRPC, a high performance, open-source universal RPC framework.
 
-version: 2.2.0+1
+version: 2.2.1
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/grpc-dart
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.10.0 <3.0.0'
 
 dependencies:
   async: ^2.2.0


### PR DESCRIPTION
`isInsecureConnectionAllowed` was only recently added to Dart SDK (6 weeks ago) and it still doesn't exist in stable release (2.9.3). This PR should wait until 2.10 is out.