### PR TITLE
Example: route guide client cleanup

### DIFF
--- a/example/route_guide/lib/src/client.dart
+++ b/example/route_guide/lib/src/client.dart
@@ -22,11 +22,10 @@ import 'generated/route_guide.pb.dart';
 import 'generated/route_guide.pbgrpc.dart';
 
 class Client {
-  ClientChannel channel;
   RouteGuideClient stub;
 
   Future<void> main(List<String> args) async {
-    channel = ClientChannel('127.0.0.1',
+    final channel = ClientChannel('127.0.0.1',
         port: 8080,
         options:
             const ChannelOptions(credentials: ChannelCredentials.insecure()));


### PR DESCRIPTION
The `channel` variable should be a local variable rather than a member of `Client`. (This is in part a followup to #286 and https://github.com/grpc/grpc.io/issues/386.)

@sigurdm @mit-mit 

I've manually tested the route guide example to ensure that it still works as intended.

Related: https://github.com/grpc/grpc.io/pull/395