### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/lib/src/auth/auth_io.dart
+++ b/lib/src/auth/auth_io.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
-
 import 'call.dart';
 import 'channel.dart';
 import 'method.dart';

--- a/lib/src/client/connection.dart
+++ b/lib/src/client/connection.dart
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
-
 import 'call.dart';
 
 import 'transport/transport.dart';


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported from dart:core