### PR TITLE
Create SecureSocket directly instead of upgrading.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 2.6.1
 
-* Create Securesocket directly when credentials.authority is not present
-  instead of always creating an insecure socket first and upgrading.
+* Create `Securesocket` directly when `ChannelCredentials.authority` is not
+  present instead of always creating an insecure socket first and upgrading.
 * Throw on insecure connections when disallowed by clients dealing with
-  socket code.
+  socket code, if set via `isInsecureConnectionAllowed`.
 
 ## 2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.6.1
+
+* Create Securesocket directly when credentials.authority is not present
+  instead of always creating an insecure socket first and upgrading.
+* Throw on insecure connections when disallowed by clients dealing with
+  socket code.
+
 ## 2.6.0
 
 * Create gRPC servers and clients with [Server|Client]TransportConnnection.

--- a/lib/src/client/call.dart
+++ b/lib/src/client/call.dart
@@ -224,7 +224,8 @@ class ClientCall<Q, R> implements Response {
   void _sendRequest(ClientConnection connection, Map<String, String> metadata) {
     try {
       _stream = connection.makeRequest(
-          _method.path, options.timeout, metadata, _onRequestError);
+          _method.path, options.timeout, metxadata, _onRequestError,
+          callOptions: options);
     } catch (e) {
       _terminateWithError(GrpcError.unavailable('Error making call: $e'));
       return;

--- a/lib/src/client/call.dart
+++ b/lib/src/client/call.dart
@@ -224,7 +224,7 @@ class ClientCall<Q, R> implements Response {
   void _sendRequest(ClientConnection connection, Map<String, String> metadata) {
     try {
       _stream = connection.makeRequest(
-          _method.path, options.timeout, metxadata, _onRequestError,
+          _method.path, options.timeout, metadata, _onRequestError,
           callOptions: options);
     } catch (e) {
       _terminateWithError(GrpcError.unavailable('Error making call: $e'));

--- a/lib/src/client/transport/xhr_transport.dart
+++ b/lib/src/client/transport/xhr_transport.dart
@@ -169,9 +169,6 @@ class XhrClientConnection extends ClientConnection {
     for (final header in metadata.keys) {
       request.setRequestHeader(header, metadata[header]);
     }
-    request.setRequestHeader('Content-Type', 'application/grpc-web+proto');
-    request.setRequestHeader('X-User-Agent', 'grpc-web-dart/0.1');
-    request.setRequestHeader('X-Grpc-Web', '1');
     // Overriding the mimetype allows us to stream and parse the data
     request.overrideMimeType('text/plain; charset=x-user-defined');
     request.responseType = 'text';

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -174,6 +174,11 @@ class Server extends ConnectionServer {
       socket.setOption(SocketOption.tcpNoDelay, true);
       final connection = ServerTransportConnection.viaSocket(socket,
           settings: http2ServerSettings);
+      if (security != null && !security.validateClient(socket)) {
+        _printSocketError('unable to serve $address:$port - '
+            'unable to validate client socket');
+        return socket.close();
+      }
       serveConnection(connection);
     }, onError: _printSocketError);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: grpc
 description: Dart implementation of gRPC, a high performance, open-source universal RPC framework.
 
-version: 2.6.0
+version: 2.6.1
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/grpc-dart


### PR DESCRIPTION
The current behavior creates an insecure socket and then attempts to upgrade it. Since socket-level checks have been rolled back in the Dart SDK, no platform does this level of check--it proves to be very tricky to handle the case of upgraded insecure sockets.

Instead, we expose the network policy via `isInsecureConnectionAllowed` function which is used by dart:io HttpClient. Any client that deals with sockets directly should also use this function to disallow insecure connections where applicable.

This change makes sure gRPC follows suit.