### PR TITLE
fix: duplicate headers in grpc-web

### DIFF
--- a/lib/src/client/transport/xhr_transport.dart
+++ b/lib/src/client/transport/xhr_transport.dart
@@ -169,9 +169,6 @@ class XhrClientConnection extends ClientConnection {
     for (final header in metadata.keys) {
       request.setRequestHeader(header, metadata[header]);
     }
-    request.setRequestHeader('Content-Type', 'application/grpc-web+proto');
-    request.setRequestHeader('X-User-Agent', 'grpc-web-dart/0.1');
-    request.setRequestHeader('X-Grpc-Web', '1');
     // Overriding the mimetype allows us to stream and parse the data
     request.overrideMimeType('text/plain; charset=x-user-defined');
     request.responseType = 'text';


### PR DESCRIPTION
`content-type`, `x-user-agent` and `x-grpc-web` headers are sent twice, causing issues with Ambassador.
Removed header setting from `_initRequest` since metadata is already populated in `makeRequest`.