### PR TITLE
Changed onMetadata to expect FutureOr

### DIFF
--- a/lib/src/server/call.dart
+++ b/lib/src/server/call.dart
@@ -39,6 +39,10 @@ abstract class ServiceCall {
   /// Returns [true] if the client has canceled this call.
   bool get isCanceled;
 
+  /// Data that can be attached to the service call to
+  /// be shared between $onMetadata even and the service methods.
+  Object customData;
+
   /// Send response headers. This is done automatically before sending the first
   /// response message, but can be done manually before the first response is
   /// ready, if necessary.

--- a/lib/src/server/handler.dart
+++ b/lib/src/server/handler.dart
@@ -128,12 +128,12 @@ class ServerHandler_ extends ServiceCall {
       return;
     }
 
-    _startStreamingRequest();
+    await _startStreamingRequest();
   }
 
-  GrpcError _onMetadata() {
+  Future<GrpcError> _onMetadata() async {
     try {
-      _service.$onMetadata(this);
+      await _service.$onMetadata(this);
     } on GrpcError catch (error) {
       return error;
     } catch (error) {
@@ -158,11 +158,12 @@ class ServerHandler_ extends ServiceCall {
     return null;
   }
 
-  void _startStreamingRequest() {
+  Future _startStreamingRequest() async {
     _requests = _descriptor.createRequestStream(_incomingSubscription);
     _incomingSubscription.onData(_onDataActive);
 
-    final error = _onMetadata();
+    final error = await _onMetadata();
+
     if (error != null) {
       if (!_requests.isClosed) {
         _requests

--- a/lib/src/server/service.dart
+++ b/lib/src/server/service.dart
@@ -102,7 +102,7 @@ abstract class Service {
   ///
   /// Services can override this method to provide common handling of incoming
   /// metadata from the client.
-  void $onMetadata(ServiceCall context) {}
+  FutureOr $onMetadata(ServiceCall context) async {}
 
   ServiceMethod $lookupMethod(String name) => _$methods[name];
 }

--- a/test/round_trip_test.dart
+++ b/test/round_trip_test.dart
@@ -49,22 +49,20 @@ class TestService extends Service {
     }
   }
 
-  int flag = 0;
-
   void $onMetadata(ServiceCall context) {
-    flag = 1;
+    context.customData = 1;
   }
 
   Future<int> getFlag(ServiceCall call, Future request) async {
-    return flag;
+    return call.customData as int;
   }
 }
 
 class TestServiceWithAsyncOnMetadata extends TestService {
   Future $onMetadata(ServiceCall context) async {
-    flag = 2;
+    context.customData = 2;
     await Future.delayed(Duration(milliseconds: 100), () async {
-      flag = 3;
+      context.customData = 3;
     });
   }
 }


### PR DESCRIPTION
This pull request changes the handler.dart file in order to add the feature suggested in issue #401 . It performs the minimum changes required to allow for async $onMetadata, but still allowing for the sync version of the method to be used instead, therefore without becoming a breaking change.

It includes several new tests. 