### PR TITLE
Support message compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.9.0-dev
-* Added support for compression/decompression 
-  [#6](https://github.com/grpc/grpc-dart/issues/6), which can be configured 
-  through `ChannelOptions` constructor's `codecRegistry` parameter or adding the 
+
+* Added support for compression/decompression, which can be configured through 
+  `ChannelOptions` constructor's `codecRegistry` parameter or adding the 
   `grpc-accept-encoding` to `metadata` parameter of `CallOptions` on the client 
   side and `codecRegistry` parameter to `Server` on the server side.
   Outgoing rpc can be compressed using the `compression` parameter on the 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 2.9.0-dev
 * Added support for compression/decompression, which can be configured through 
-  `ChannelOptions` constructor's `codec` parameter or adding the 
+  `ChannelOptions` constructor's `codecRegistry` parameter or adding the 
   `grpc-accept-encoding` to `metadata` parameter of `CallOptions` on the client 
-  side and `codec` parameter to `Server` on the server side.
+  side and `codecRegistry` parameter to `Server` on the server side.
 
 ## 2.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.9.0-dev
+* Added support for compression/decompression, which can be configured through 
+  `ChannelOptions` constructor's `codec` parameter or adding the 
+  `grpc-accept-encoding` to `metadata` parameter of `CallOptions` on the client 
+  side and `codec` parameter to `Server` on the server side.
+
 ## 2.8.0
 
 * Added support for client interceptors, which can be configured through

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## 2.9.0-dev
-* Added support for compression/decompression, which can be configured through 
-  `ChannelOptions` constructor's `codecRegistry` parameter or adding the 
+* Added support for compression/decompression 
+  [#6](https://github.com/grpc/grpc-dart/issues/6), which can be configured 
+  through `ChannelOptions` constructor's `codecRegistry` parameter or adding the 
   `grpc-accept-encoding` to `metadata` parameter of `CallOptions` on the client 
   side and `codecRegistry` parameter to `Server` on the server side.
+  Outgoing rpc can be compressed using the `compression` parameter on the 
+  `CallOptions`.
 
 ## 2.8.0
 

--- a/example/helloworld/bin/client.dart
+++ b/example/helloworld/bin/client.dart
@@ -35,7 +35,7 @@ Future<void> main(List<String> args) async {
   try {
     final response = await stub.sayHello(
       HelloRequest()..name = name,
-      options: CallOptions(metadata: {'grpc-accept-encoding': 'gzip'}),
+      options: CallOptions(compression: const Gzip()),
     );
     print('Greeter client received: ${response.message}');
   } catch (e) {

--- a/example/helloworld/bin/client.dart
+++ b/example/helloworld/bin/client.dart
@@ -15,7 +15,6 @@
 
 /// Dart implementation of the gRPC helloworld.Greeter client.
 import 'package:grpc/grpc.dart';
-
 import 'package:helloworld/src/generated/helloworld.pb.dart';
 import 'package:helloworld/src/generated/helloworld.pbgrpc.dart';
 
@@ -23,14 +22,21 @@ Future<void> main(List<String> args) async {
   final channel = ClientChannel(
     'localhost',
     port: 50051,
-    options: const ChannelOptions(credentials: ChannelCredentials.insecure()),
+    options: ChannelOptions(
+      credentials: ChannelCredentials.insecure(),
+      codecRegistry:
+          CodecRegistry(codecs: const [const Gzip(), const Identity()]),
+    ),
   );
   final stub = GreeterClient(channel);
 
   final name = args.isNotEmpty ? args[0] : 'world';
 
   try {
-    final response = await stub.sayHello(HelloRequest()..name = name);
+    final response = await stub.sayHello(
+      HelloRequest()..name = name,
+      options: CallOptions(metadata: {'grpc-accept-encoding': 'gzip'}),
+    );
     print('Greeter client received: ${response.message}');
   } catch (e) {
     print('Caught error: $e');

--- a/example/helloworld/bin/client.dart
+++ b/example/helloworld/bin/client.dart
@@ -22,11 +22,12 @@ Future<void> main(List<String> args) async {
   final channel = ClientChannel(
     'localhost',
     port: 50051,
-      options: ChannelOptions(
-        credentials: ChannelCredentials.insecure(),
-        codecRegistry:
-        CodecRegistry(codecs: const [GzipCodec(), IdentityCodec()]),
-      ),
+    options: ChannelOptions(
+      credentials: ChannelCredentials.insecure(),
+      codecRegistry:
+          CodecRegistry(codecs: const [GzipCodec(), IdentityCodec()]),
+    ),
+  );
   final stub = GreeterClient(channel);
 
   final name = args.isNotEmpty ? args[0] : 'world';

--- a/example/helloworld/bin/client.dart
+++ b/example/helloworld/bin/client.dart
@@ -22,12 +22,11 @@ Future<void> main(List<String> args) async {
   final channel = ClientChannel(
     'localhost',
     port: 50051,
-    options: ChannelOptions(
-      credentials: ChannelCredentials.insecure(),
-      codecRegistry:
-          CodecRegistry(codecs: const [const Gzip(), const Identity()]),
-    ),
-  );
+      options: ChannelOptions(
+        credentials: ChannelCredentials.insecure(),
+        codecRegistry:
+        CodecRegistry(codecs: const [GzipCodec(), IdentityCodec()]),
+      ),
   final stub = GreeterClient(channel);
 
   final name = args.isNotEmpty ? args[0] : 'world';
@@ -35,7 +34,7 @@ Future<void> main(List<String> args) async {
   try {
     final response = await stub.sayHello(
       HelloRequest()..name = name,
-      options: CallOptions(compression: const Gzip()),
+      options: CallOptions(compression: const GzipCodec()),
     );
     print('Greeter client received: ${response.message}');
   } catch (e) {

--- a/example/helloworld/bin/server.dart
+++ b/example/helloworld/bin/server.dart
@@ -29,7 +29,7 @@ Future<void> main(List<String> args) async {
   final server = Server(
     [GreeterService()],
     const <Interceptor>[],
-    CodecRegistry(codecs: const [const GzipCodec(), const IdentityCodec()]),
+    CodecRegistry(codecs: const [GzipCodec(), IdentityCodec()]),
   );
   await server.serve(port: 50051);
   print('Server listening on port ${server.port}...');

--- a/example/helloworld/bin/server.dart
+++ b/example/helloworld/bin/server.dart
@@ -29,7 +29,7 @@ Future<void> main(List<String> args) async {
   final server = Server(
     [GreeterService()],
     const <Interceptor>[],
-    CodecRegistry(codecs: const [const Gzip(), const Identity()]),
+    CodecRegistry(codecs: const [const GzipCodec(), const IdentityCodec()]),
   );
   await server.serve(port: 50051);
   print('Server listening on port ${server.port}...');

--- a/example/helloworld/bin/server.dart
+++ b/example/helloworld/bin/server.dart
@@ -15,7 +15,6 @@
 
 /// Dart implementation of the gRPC helloworld.Greeter server.
 import 'package:grpc/grpc.dart';
-
 import 'package:helloworld/src/generated/helloworld.pb.dart';
 import 'package:helloworld/src/generated/helloworld.pbgrpc.dart';
 
@@ -27,7 +26,11 @@ class GreeterService extends GreeterServiceBase {
 }
 
 Future<void> main(List<String> args) async {
-  final server = Server([GreeterService()]);
+  final server = Server(
+    [GreeterService()],
+    const <Interceptor>[],
+    CodecRegistry(codecs: const [const Gzip(), const Identity()]),
+  );
   await server.serve(port: 50051);
   print('Server listening on port ${server.port}...');
 }

--- a/lib/grpc.dart
+++ b/lib/grpc.dart
@@ -31,10 +31,8 @@ export 'src/client/common.dart' show Response, ResponseStream, ResponseFuture;
 export 'src/client/connection.dart' show ConnectionState;
 export 'src/client/http2_channel.dart'
     show ClientChannel, ClientTransportConnectorChannel;
-
 export 'src/client/interceptor.dart'
     show ClientInterceptor, ClientUnaryInvoker, ClientStreamingInvoker;
-
 export 'src/client/method.dart' show ClientMethod;
 export 'src/client/options.dart'
     show
@@ -58,11 +56,10 @@ export 'src/server/server.dart'
         Server;
 export 'src/server/service.dart' show ServiceMethod, Service;
 export 'src/shared/codec.dart' show Codec, Identity, Gzip;
+export 'src/shared/codec_registry.dart';
 export 'src/shared/message.dart'
     show GrpcMessage, GrpcMetadata, GrpcData, grpcDecompressor;
-
 export 'src/shared/profiler.dart' show isTimelineLoggingEnabled;
-
 export 'src/shared/security.dart'
     show supportedAlpnProtocols, createSecurityContext;
 export 'src/shared/status.dart' show StatusCode, GrpcError;

--- a/lib/grpc.dart
+++ b/lib/grpc.dart
@@ -57,6 +57,7 @@ export 'src/server/server.dart'
         ConnectionServer,
         Server;
 export 'src/server/service.dart' show ServiceMethod, Service;
+export 'src/shared/codec.dart' show Codec, Identity, Gzip;
 export 'src/shared/message.dart'
     show GrpcMessage, GrpcMetadata, GrpcData, grpcDecompressor;
 

--- a/lib/grpc.dart
+++ b/lib/grpc.dart
@@ -55,7 +55,7 @@ export 'src/server/server.dart'
         ConnectionServer,
         Server;
 export 'src/server/service.dart' show ServiceMethod, Service;
-export 'src/shared/codec.dart' show Codec, Identity, Gzip;
+export 'src/shared/codec.dart' show Codec, IdentityCodec, GzipCodec;
 export 'src/shared/codec_registry.dart';
 export 'src/shared/message.dart'
     show GrpcMessage, GrpcMetadata, GrpcData, grpcDecompressor;

--- a/lib/src/client/call.dart
+++ b/lib/src/client/call.dart
@@ -17,6 +17,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';
 
+import 'package:grpc/grpc.dart';
 import 'package:grpc/src/generated/google/rpc/status.pb.dart';
 import 'package:meta/meta.dart';
 import 'package:protobuf/protobuf.dart';
@@ -34,6 +35,7 @@ const _reservedHeaders = [
   'te',
   'grpc-timeout',
   'grpc-accept-encoding',
+  'grpc-encoding',
   'user-agent',
 ];
 
@@ -55,8 +57,14 @@ class CallOptions {
   final Map<String, String> metadata;
   final Duration timeout;
   final List<MetadataProvider> metadataProviders;
+  final Codec compression;
 
-  CallOptions._(this.metadata, this.timeout, this.metadataProviders);
+  CallOptions._(
+    this.metadata,
+    this.timeout,
+    this.metadataProviders,
+    this.compression,
+  );
 
   /// Creates a [CallOptions] object.
   ///
@@ -64,12 +72,18 @@ class CallOptions {
   /// configure per-RPC metadata [providers]. The metadata [providers] are
   /// invoked in order for every RPC, and can modify the outgoing metadata
   /// (including metadata provided by previous providers).
-  factory CallOptions(
-      {Map<String, String> metadata,
-      Duration timeout,
-      List<MetadataProvider> providers}) {
-    return CallOptions._(Map.unmodifiable(metadata ?? {}), timeout,
-        List.unmodifiable(providers ?? []));
+  factory CallOptions({
+    Map<String, String> metadata,
+    Duration timeout,
+    List<MetadataProvider> providers,
+    Codec compression,
+  }) {
+    return CallOptions._(
+      Map.unmodifiable(metadata ?? {}),
+      timeout,
+      List.unmodifiable(providers ?? []),
+      compression,
+    );
   }
 
   factory CallOptions.from(Iterable<CallOptions> options) =>
@@ -81,8 +95,13 @@ class CallOptions {
     final mergedTimeout = other.timeout ?? timeout;
     final mergedProviders = List.from(metadataProviders)
       ..addAll(other.metadataProviders);
-    return CallOptions._(Map.unmodifiable(mergedMetadata), mergedTimeout,
-        List.unmodifiable(mergedProviders));
+    final mergedCompression = other.compression ?? compression;
+    return CallOptions._(
+      Map.unmodifiable(mergedMetadata),
+      mergedTimeout,
+      List.unmodifiable(mergedProviders),
+      mergedCompression,
+    );
   }
 }
 
@@ -109,7 +128,7 @@ class WebCallOptions extends CallOptions {
   WebCallOptions._(Map<String, String> metadata, Duration timeout,
       List<MetadataProvider> metadataProviders,
       {this.bypassCorsPreflight, this.withCredentials})
-      : super._(metadata, timeout, metadataProviders);
+      : super._(metadata, timeout, metadataProviders, null);
 
   /// Creates a [WebCallOptions] object.
   ///

--- a/lib/src/client/call.dart
+++ b/lib/src/client/call.dart
@@ -246,7 +246,12 @@ class ClientCall<Q, R> implements Response {
   void _sendRequest(ClientConnection connection, Map<String, String> metadata) {
     try {
       _stream = connection.makeRequest(
-          _method.path, options.timeout, metadata, _onRequestError);
+        _method.path,
+        options.timeout,
+        metadata,
+        _onRequestError,
+        callOptions: options,
+      );
     } catch (e) {
       _terminateWithError(GrpcError.unavailable('Error making call: $e'));
       return;

--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -162,7 +162,7 @@ class Http2ClientConnection implements connection.ClientConnection {
       compressionCodec,
       userAgent: options.userAgent,
       grpcAcceptEncodings: callOptions.metadata['grpc-accept-encoding'] ??
-          options.codecRegistry?.encodings(),
+          options.codecRegistry?.supportedEncodings,
     );
     final stream = _transportConnection.makeRequest(headers);
     return Http2TransportStream(
@@ -309,7 +309,7 @@ class Http2ClientConnection implements connection.ClientConnection {
       if (grpcAcceptEncodings != null)
         Header.ascii('grpc-accept-encoding', grpcAcceptEncodings),
       if (compressionCodec != null)
-        Header.ascii('grpc-encoding', compressionCodec.messageEncoding())
+        Header.ascii('grpc-encoding', compressionCodec.encodingName)
     ]);
     metadata?.forEach((key, value) {
       headers.add(Header(ascii.encode(key), utf8.encode(value)));

--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -20,7 +20,6 @@ import 'dart:io';
 import 'package:http2/transport.dart';
 import 'package:meta/meta.dart';
 
-import '../shared/codec.dart';
 import '../shared/timeout.dart';
 import 'call.dart';
 import 'client_transport_connector.dart';
@@ -269,9 +268,15 @@ class Http2ClientConnection implements connection.ClientConnection {
     _timer = Timer(_currentReconnectDelay, _handleReconnect);
   }
 
-  static List<Header> createCallHeaders(bool useTls, String authority,
-      String path, Duration timeout, Map<String, String> metadata,
-      {String userAgent, Codec codec = const Identity()}) {
+  static List<Header> createCallHeaders(
+    bool useTls,
+    String authority,
+    String path,
+    Duration timeout,
+    Map<String, String> metadata, {
+    String userAgent,
+    String codec = 'identity',
+  }) {
     final headers = [
       _methodPost,
       useTls ? _schemeHttps : _schemeHttp,
@@ -284,7 +289,7 @@ class Http2ClientConnection implements connection.ClientConnection {
     headers.addAll([
       _contentTypeGrpc,
       _teTrailers,
-      Header.ascii('grpc-accept-encoding', codec.messageEncoding()),
+      Header.ascii('grpc-accept-encoding', codec),
       Header.ascii('user-agent', userAgent ?? defaultUserAgent),
     ]);
     metadata?.forEach((key, value) {

--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -153,7 +153,8 @@ class Http2ClientConnection implements connection.ClientConnection {
       {CallOptions callOptions}) {
     final headers = createCallHeaders(credentials.isSecure,
         _transportConnector.authority, path, timeout, metadata,
-        userAgent: options.userAgent, codec: options.codec);
+        userAgent: options.userAgent,
+        codec: callOptions.metadata['grpc-accept-encoding'] ?? options.codec);
     final stream = _transportConnection.makeRequest(headers);
     return Http2TransportStream(stream, onRequestFailure);
   }

--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -298,11 +298,8 @@ class Http2ClientConnection implements connection.ClientConnection {
       useTls ? _schemeHttps : _schemeHttp,
       Header(ascii.encode(':path'), utf8.encode(path)),
       Header(ascii.encode(':authority'), utf8.encode(authority)),
-    ];
-    if (timeout != null) {
-      headers.add(Header.ascii('grpc-timeout', toTimeoutString(timeout)));
-    }
-    headers.addAll([
+      if (timeout != null)
+        Header.ascii('grpc-timeout', toTimeoutString(timeout)),
       _contentTypeGrpc,
       _teTrailers,
       Header.ascii('user-agent', userAgent ?? defaultUserAgent),
@@ -310,7 +307,7 @@ class Http2ClientConnection implements connection.ClientConnection {
         Header.ascii('grpc-accept-encoding', grpcAcceptEncodings),
       if (compressionCodec != null)
         Header.ascii('grpc-encoding', compressionCodec.encodingName)
-    ]);
+    ];
     metadata?.forEach((key, value) {
       headers.add(Header(ascii.encode(key), utf8.encode(value)));
     });

--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -162,8 +162,7 @@ class Http2ClientConnection implements connection.ClientConnection {
       compressionCodec,
       userAgent: options.userAgent,
       grpcAcceptEncodings: callOptions.metadata['grpc-accept-encoding'] ??
-          options.codecRegistry?.encodings() ??
-          compressionCodec?.messageEncoding(),
+          options.codecRegistry?.encodings(),
     );
     final stream = _transportConnection.makeRequest(headers);
     return Http2TransportStream(

--- a/lib/src/client/options.dart
+++ b/lib/src/client/options.dart
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 import 'dart:math';
+
+import '../shared/codec.dart';
 import 'transport/http2_credentials.dart';
 
 const defaultIdleTimeout = Duration(minutes: 5);
@@ -44,6 +46,7 @@ Duration defaultBackoffStrategy(Duration lastBackoff) {
 class ChannelOptions {
   final ChannelCredentials credentials;
   final Duration idleTimeout;
+  final Codec codec;
 
   /// The maximum time a single connection will be used for new requests.
   final Duration connectionTimeout;
@@ -56,5 +59,6 @@ class ChannelOptions {
     this.userAgent = defaultUserAgent,
     this.backoffStrategy = defaultBackoffStrategy,
     this.connectionTimeout = defaultConnectionTimeOut,
+    this.codec = const Identity(),
   });
 }

--- a/lib/src/client/options.dart
+++ b/lib/src/client/options.dart
@@ -15,7 +15,6 @@
 
 import 'dart:math';
 
-import '../shared/codec.dart';
 import 'transport/http2_credentials.dart';
 
 const defaultIdleTimeout = Duration(minutes: 5);
@@ -46,7 +45,7 @@ Duration defaultBackoffStrategy(Duration lastBackoff) {
 class ChannelOptions {
   final ChannelCredentials credentials;
   final Duration idleTimeout;
-  final Codec codec;
+  final String codec;
 
   /// The maximum time a single connection will be used for new requests.
   final Duration connectionTimeout;
@@ -59,6 +58,6 @@ class ChannelOptions {
     this.userAgent = defaultUserAgent,
     this.backoffStrategy = defaultBackoffStrategy,
     this.connectionTimeout = defaultConnectionTimeOut,
-    this.codec = const Identity(),
+    this.codec = 'identity',
   });
 }

--- a/lib/src/client/options.dart
+++ b/lib/src/client/options.dart
@@ -15,6 +15,8 @@
 
 import 'dart:math';
 
+import 'package:grpc/src/shared/codec_registry.dart';
+
 import 'transport/http2_credentials.dart';
 
 const defaultIdleTimeout = Duration(minutes: 5);
@@ -45,7 +47,7 @@ Duration defaultBackoffStrategy(Duration lastBackoff) {
 class ChannelOptions {
   final ChannelCredentials credentials;
   final Duration idleTimeout;
-  final String codec;
+  final CodecRegistry codecRegistry;
 
   /// The maximum time a single connection will be used for new requests.
   final Duration connectionTimeout;
@@ -58,6 +60,6 @@ class ChannelOptions {
     this.userAgent = defaultUserAgent,
     this.backoffStrategy = defaultBackoffStrategy,
     this.connectionTimeout = defaultConnectionTimeOut,
-    this.codec = 'identity',
+    this.codecRegistry,
   });
 }

--- a/lib/src/client/options.dart
+++ b/lib/src/client/options.dart
@@ -15,8 +15,7 @@
 
 import 'dart:math';
 
-import 'package:grpc/src/shared/codec_registry.dart';
-
+import '../shared/codec_registry.dart';
 import 'transport/http2_credentials.dart';
 
 const defaultIdleTimeout = Duration(minutes: 5);

--- a/lib/src/client/transport/http2_transport.dart
+++ b/lib/src/client/transport/http2_transport.dart
@@ -15,11 +15,11 @@
 
 import 'dart:async';
 
+import 'package:grpc/grpc.dart';
 import 'package:http2/transport.dart';
 
 import '../../shared/message.dart';
 import '../../shared/streams.dart';
-
 import 'transport.dart';
 
 class Http2TransportStream extends GrpcTransportStream {
@@ -30,10 +30,11 @@ class Http2TransportStream extends GrpcTransportStream {
 
   StreamSink<List<int>> get outgoingMessages => _outgoingMessages.sink;
 
-  Http2TransportStream(this._transportStream, this._onError)
+  Http2TransportStream(
+      this._transportStream, this._onError, CodecRegistry codecRegistry)
       : incomingMessages = _transportStream.incomingMessages
             .transform(GrpcHttpDecoder())
-            .transform(grpcDecompressor()) {
+            .transform(grpcDecompressor(codecRegistry: codecRegistry)) {
     _outgoingMessages.stream
         .map(frame)
         .map<StreamMessage>((bytes) => DataStreamMessage(bytes))

--- a/lib/src/client/transport/http2_transport.dart
+++ b/lib/src/client/transport/http2_transport.dart
@@ -31,12 +31,15 @@ class Http2TransportStream extends GrpcTransportStream {
   StreamSink<List<int>> get outgoingMessages => _outgoingMessages.sink;
 
   Http2TransportStream(
-      this._transportStream, this._onError, CodecRegistry codecRegistry)
-      : incomingMessages = _transportStream.incomingMessages
+    this._transportStream,
+    this._onError,
+    CodecRegistry codecRegistry,
+    Codec compression,
+  ) : incomingMessages = _transportStream.incomingMessages
             .transform(GrpcHttpDecoder())
             .transform(grpcDecompressor(codecRegistry: codecRegistry)) {
     _outgoingMessages.stream
-        .map(frame)
+        .map((payload) => frame(payload, compression))
         .map<StreamMessage>((bytes) => DataStreamMessage(bytes))
         .handleError(_onError)
         .listen(_transportStream.outgoingMessages.add,

--- a/lib/src/server/handler.dart
+++ b/lib/src/server/handler.dart
@@ -287,7 +287,8 @@ class ServerHandler_ extends ServiceCall {
     // TODO(jakobr): Should come from package:http2?
     final outgoingHeadersMap = <String, String>{
       ':status': '200',
-      'content-type': 'application/grpc'
+      'content-type': 'application/grpc',
+      'grpc-encoding': _codec.messageEncoding(),
     };
 
     outgoingHeadersMap.addAll(_customHeaders);

--- a/lib/src/server/handler.dart
+++ b/lib/src/server/handler.dart
@@ -41,7 +41,7 @@ class ServerHandler_ extends ServiceCall {
   ServiceMethod _descriptor;
 
   Map<String, String> _clientMetadata;
-  Codec _callEncodingCodec = const Identity();
+  Codec _callEncodingCodec;
 
   StreamController _requests;
   bool _hasReceivedRequest = false;
@@ -123,11 +123,10 @@ class ServerHandler_ extends ServiceCall {
     final clientEncodings = _clientMetadata['grpc-accept-encoding'].split(',');
     final clientEncoding = clientEncodings.firstWhere(
         (element) => _supportedCodecs.contains(element),
-        orElse: () => 'identity');
+        orElse: () => '');
 
-    if (clientEncoding != null) {
-      _callEncodingCodec =
-          CodecRegistry().lookupCodec(clientEncoding) ?? const Identity();
+    if (clientEncoding.isNotEmpty) {
+      _callEncodingCodec = CodecRegistry().lookupCodec(clientEncoding);
     }
 
     _service = _serviceLookup(serviceName);
@@ -303,8 +302,12 @@ class ServerHandler_ extends ServiceCall {
     final outgoingHeadersMap = <String, String>{
       ':status': '200',
       'content-type': 'application/grpc',
-      'grpc-encoding': _callEncodingCodec.messageEncoding(),
     };
+
+    if (_callEncodingCodec != null) {
+      outgoingHeadersMap['grpc-encoding'] =
+          _callEncodingCodec.messageEncoding();
+    }
 
     outgoingHeadersMap.addAll(_customHeaders);
     _customHeaders = null;

--- a/lib/src/server/handler.dart
+++ b/lib/src/server/handler.dart
@@ -16,10 +16,10 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:grpc/src/shared/codec_registry.dart';
 import 'package:http2/transport.dart';
 
 import '../shared/codec.dart';
+import '../shared/codec_registry.dart';
 import '../shared/message.dart';
 import '../shared/status.dart';
 import '../shared/streams.dart';

--- a/lib/src/server/handler.dart
+++ b/lib/src/server/handler.dart
@@ -23,7 +23,6 @@ import '../shared/message.dart';
 import '../shared/status.dart';
 import '../shared/streams.dart';
 import '../shared/timeout.dart';
-
 import 'call.dart';
 import 'interceptor.dart';
 import 'service.dart';
@@ -76,8 +75,8 @@ class ServerHandler_ extends ServiceCall {
     _stream.onTerminated = (_) => cancel();
 
     _incomingSubscription = _stream.incomingMessages
-        .transform(GrpcHttpDecoder(_codec))
-        .transform(grpcDecompressor(_codec))
+        .transform(GrpcHttpDecoder())
+        .transform(grpcDecompressor())
         .listen(_onDataIdle,
             onError: _onError, onDone: _onDoneError, cancelOnError: true);
     _stream.outgoingMessages.done.then((_) {

--- a/lib/src/server/handler.dart
+++ b/lib/src/server/handler.dart
@@ -82,7 +82,7 @@ class ServerHandler_ extends ServiceCall {
 
     _incomingSubscription = _stream.incomingMessages
         .transform(GrpcHttpDecoder())
-        .transform(grpcDecompressor())
+        .transform(grpcDecompressor(codecRegistry: _codecRegistry))
         .listen(_onDataIdle,
             onError: _onError, onDone: _onDoneError, cancelOnError: true);
     _stream.outgoingMessages.done.then((_) {

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -19,9 +19,7 @@ import 'dart:io';
 import 'package:http2/transport.dart';
 import 'package:meta/meta.dart';
 
-import '../shared/codec.dart';
 import '../shared/security.dart';
-
 import 'handler.dart';
 import 'interceptor.dart';
 import 'service.dart';
@@ -85,15 +83,16 @@ class ServerTlsCredentials extends ServerCredentials {
 class ConnectionServer {
   final Map<String, Service> _services = {};
   final List<Interceptor> _interceptors;
-  final Codec _codec;
+  final Set<String> _codec;
 
   final _connections = <ServerTransportConnection>[];
 
   /// Create a server for the given [services].
-  ConnectionServer(List<Service> services,
-      [List<Interceptor> interceptors = const <Interceptor>[],
-      Codec codec = const Identity()])
-      : assert(codec != null),
+  ConnectionServer(
+    List<Service> services, [
+    List<Interceptor> interceptors = const <Interceptor>[],
+    Set<String> codec = const {'identity'},
+  ])  : assert(codec != null),
         _codec = codec,
         _interceptors = interceptors {
     for (final service in services) {
@@ -139,10 +138,11 @@ class Server extends ConnectionServer {
   SecureServerSocket _secureServer;
 
   /// Create a server for the given [services].
-  Server(List<Service> services,
-      [List<Interceptor> interceptors = const <Interceptor>[],
-      Codec codec = const Identity()])
-      : assert(codec != null),
+  Server(
+    List<Service> services, [
+    List<Interceptor> interceptors = const <Interceptor>[],
+    Set<String> codec = const {'identity'},
+  ])  : assert(codec != null),
         super(services, interceptors, codec);
 
   /// The port that the server is listening on, or `null` if the server is not

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -91,7 +91,7 @@ class ConnectionServer {
   ConnectionServer(
     List<Service> services, [
     List<Interceptor> interceptors = const <Interceptor>[],
-    Set<String> codec = const {'identity'},
+    Set<String> codec = const {},
   ])  : assert(codec != null),
         _codec = codec,
         _interceptors = interceptors {
@@ -141,7 +141,7 @@ class Server extends ConnectionServer {
   Server(
     List<Service> services, [
     List<Interceptor> interceptors = const <Interceptor>[],
-    Set<String> codec = const {'identity'},
+    Set<String> codec = const {},
   ])  : assert(codec != null),
         super(services, interceptors, codec);
 

--- a/lib/src/shared/codec.dart
+++ b/lib/src/shared/codec.dart
@@ -1,6 +1,6 @@
 import 'package:archive/archive.dart';
 
-class Codec {
+abstract class Codec {
   /// Returns the message encoding that this compressor uses.
   ///
   /// This can be values such as "gzip", "deflate", "snappy", etc.
@@ -20,18 +20,18 @@ class Codec {
 class Identity implements Codec {
   const Identity();
 
-  @Override
-  public List<int> decompress(List<int> inputStream) {
+  @override
+  List<int> decompress(List<int> inputStream) {
   return inputStream;
   }
 
-  @Override
-  public String getMessageEncoding() {
+  @override
+  String getMessageEncoding() {
     return "identity";
   }
 
-  @Override
-  public List<int> compress(List<int> outputStream) {
+  @override
+  List<int> compress(List<int> outputStream) {
     return outputStream;
   }
 }
@@ -40,18 +40,18 @@ class Identity implements Codec {
 class Gzip implements Codec {
   const Gzip();
 
-  @Override
-  public List<int> decompress(List<int> inputStream) {
-    return GZipEncoder().encode(inputStream);
+  @override
+  List<int> decompress(List<int> inputStream) {
+    return GZipDecoder().decodeBytes(inputStream);
   }
 
-  @Override
-  public String getMessageEncoding() {
+  @override
+  String getMessageEncoding() {
     return "gzip";
   }
 
-  @Override
-  public List<int> compress(List<int> outputStream) {
-    return GZipDecoder().decodeBytes(outputStream);
+  @override
+  List<int> compress(List<int> outputStream) {
+    return GZipEncoder().encode(outputStream);
   }
 }

--- a/lib/src/shared/codec.dart
+++ b/lib/src/shared/codec.dart
@@ -7,10 +7,10 @@ abstract class Codec {
   String messageEncoding();
 
   /// Wraps an existing output stream with a compressed output.
-  List<int> compress(List<int> os);
+  List<int> compress(List<int> outputStream);
 
   /// Wraps an existing output stream with a uncompressed input data.
-  List<int> decompress(List<int> os);
+  List<int> decompress(List<int> inputStream);
 }
 
 /// The "identity", or "none" codec.
@@ -21,11 +21,6 @@ class Identity implements Codec {
   const Identity();
 
   @override
-  List<int> decompress(List<int> inputStream) {
-    return inputStream;
-  }
-
-  @override
   String messageEncoding() {
     return "identity";
   }
@@ -34,16 +29,16 @@ class Identity implements Codec {
   List<int> compress(List<int> outputStream) {
     return outputStream;
   }
+
+  @override
+  List<int> decompress(List<int> inputStream) {
+    return inputStream;
+  }
 }
 
 /// A gzip compressor and decompressor.
 class Gzip implements Codec {
   const Gzip();
-
-  @override
-  List<int> decompress(List<int> inputStream) {
-    return GZipDecoder().decodeBytes(inputStream);
-  }
 
   @override
   String messageEncoding() {
@@ -53,5 +48,10 @@ class Gzip implements Codec {
   @override
   List<int> compress(List<int> outputStream) {
     return GZipEncoder().encode(outputStream);
+  }
+
+  @override
+  List<int> decompress(List<int> inputStream) {
+    return GZipDecoder().decodeBytes(inputStream);
   }
 }

--- a/lib/src/shared/codec.dart
+++ b/lib/src/shared/codec.dart
@@ -1,0 +1,57 @@
+import 'package:archive/archive.dart';
+
+class Codec {
+  /// Returns the message encoding that this compressor uses.
+  ///
+  /// This can be values such as "gzip", "deflate", "snappy", etc.
+  String getMessageEncoding();
+
+  /// Wraps an existing output stream with a compressed output.
+  List<int> compress(List<int> os);
+
+  /// Wraps an existing output stream with a uncompressed input data.
+  List<int> decompress(List<int> os);
+}
+
+/// The "identity", or "none" codec.
+///
+/// This codec is special in that it can be used to explicitly disable Call
+/// compression on a Channel that by default compresses.
+class Identity implements Codec {
+  const Identity();
+
+  @Override
+  public List<int> decompress(List<int> inputStream) {
+  return inputStream;
+  }
+
+  @Override
+  public String getMessageEncoding() {
+    return "identity";
+  }
+
+  @Override
+  public List<int> compress(List<int> outputStream) {
+    return outputStream;
+  }
+}
+
+/// A gzip compressor and decompressor.
+class Gzip implements Codec {
+  const Gzip();
+
+  @Override
+  public List<int> decompress(List<int> inputStream) {
+    return GZipEncoder().encode(inputStream);
+  }
+
+  @Override
+  public String getMessageEncoding() {
+    return "gzip";
+  }
+
+  @Override
+  public List<int> compress(List<int> outputStream) {
+    return GZipDecoder().decodeBytes(outputStream);
+  }
+}

--- a/lib/src/shared/codec.dart
+++ b/lib/src/shared/codec.dart
@@ -1,57 +1,68 @@
+// Copyright (c) 2020, the gRPC project authors. Please see the AUTHORS file
+// for details. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'package:archive/archive.dart';
 
 abstract class Codec {
   /// Returns the message encoding that this compressor uses.
   ///
   /// This can be values such as "gzip", "deflate", "snappy", etc.
-  String messageEncoding();
+  String get encodingName;
 
   /// Wraps an existing output stream with a compressed output.
-  List<int> compress(List<int> outputStream);
+  List<int> compress(List<int> data);
 
   /// Wraps an existing output stream with a uncompressed input data.
-  List<int> decompress(List<int> inputStream);
+  List<int> decompress(List<int> data);
 }
 
 /// The "identity", or "none" codec.
 ///
 /// This codec is special in that it can be used to explicitly disable Call
 /// compression on a Channel that by default compresses.
-class Identity implements Codec {
-  const Identity();
+class IdentityCodec implements Codec {
+  const IdentityCodec();
 
   @override
-  String messageEncoding() {
-    return "identity";
+  String get encodingName => "identity";
+
+  @override
+  List<int> compress(List<int> data) {
+    return data;
   }
 
   @override
-  List<int> compress(List<int> outputStream) {
-    return outputStream;
-  }
-
-  @override
-  List<int> decompress(List<int> inputStream) {
-    return inputStream;
+  List<int> decompress(List<int> data) {
+    return data;
   }
 }
 
 /// A gzip compressor and decompressor.
-class Gzip implements Codec {
-  const Gzip();
+class GzipCodec implements Codec {
+  const GzipCodec();
 
   @override
-  String messageEncoding() {
-    return "gzip";
+  String get encodingName => "gzip";
+
+  @override
+  List<int> compress(List<int> data) {
+    return GZipEncoder().encode(data);
   }
 
   @override
-  List<int> compress(List<int> outputStream) {
-    return GZipEncoder().encode(outputStream);
-  }
-
-  @override
-  List<int> decompress(List<int> inputStream) {
-    return GZipDecoder().decodeBytes(inputStream);
+  List<int> decompress(List<int> data) {
+    return GZipDecoder().decodeBytes(data);
   }
 }

--- a/lib/src/shared/codec.dart
+++ b/lib/src/shared/codec.dart
@@ -4,7 +4,7 @@ abstract class Codec {
   /// Returns the message encoding that this compressor uses.
   ///
   /// This can be values such as "gzip", "deflate", "snappy", etc.
-  String getMessageEncoding();
+  String messageEncoding();
 
   /// Wraps an existing output stream with a compressed output.
   List<int> compress(List<int> os);
@@ -26,7 +26,7 @@ class Identity implements Codec {
   }
 
   @override
-  String getMessageEncoding() {
+  String messageEncoding() {
     return "identity";
   }
 
@@ -46,7 +46,7 @@ class Gzip implements Codec {
   }
 
   @override
-  String getMessageEncoding() {
+  String messageEncoding() {
     return "gzip";
   }
 

--- a/lib/src/shared/codec.dart
+++ b/lib/src/shared/codec.dart
@@ -22,7 +22,7 @@ class Identity implements Codec {
 
   @override
   List<int> decompress(List<int> inputStream) {
-  return inputStream;
+    return inputStream;
   }
 
   @override

--- a/lib/src/shared/codec_registry.dart
+++ b/lib/src/shared/codec_registry.dart
@@ -1,9 +1,15 @@
 import 'codec.dart';
 
 class CodecRegistry {
-  CodecRegistry() {
+  CodecRegistry._() {
     final allCodecs = [const Identity(), const Gzip()];
-    allCodecs.map((codec) => codecs[codec.getMessageEncoding()] = codec);
+    allCodecs.forEach((codec) => register(codec));
+  }
+
+  static final CodecRegistry _instance = CodecRegistry._();
+
+  factory CodecRegistry() {
+    return _instance;
   }
 
   final Map<String, Codec> codecs = {};
@@ -12,8 +18,8 @@ class CodecRegistry {
     return codecs[codecName];
   }
 
-  register(Codec codec) {
-    final encoding = codec.getMessageEncoding();
+  void register(Codec codec) {
+    final encoding = codec.messageEncoding();
     assert(!encoding.contains(","),
         "Comma is currently not allowed in message encoding");
     codecs[encoding] = codec;

--- a/lib/src/shared/codec_registry.dart
+++ b/lib/src/shared/codec_registry.dart
@@ -1,27 +1,36 @@
 import 'codec.dart';
 
+/// Encloses classes related to the compression and decompression of messages.
 class CodecRegistry {
-  CodecRegistry._() {
-    final allCodecs = [const Identity(), const Gzip()];
-    allCodecs.forEach((codec) => register(codec));
+  CodecRegistry({List<Codec> codecs = const [const Identity()]})
+      : assert(codecs != null) {
+    codecs.forEach((codec) => register(codec));
   }
 
-  static final CodecRegistry _instance = CodecRegistry._();
-
-  factory CodecRegistry() {
-    return _instance;
+  factory CodecRegistry.empty() {
+    return CodecRegistry(codecs: []);
   }
 
-  final Map<String, Codec> codecs = {};
+  final Map<String, Codec> _codecs = {};
+  final List<String> _allSupportedCodecs = [];
 
   Codec lookupCodec(String codecName) {
-    return codecs[codecName];
+    return _codecs[codecName];
   }
 
+  String encodings() {
+    return _allSupportedCodecs.join(',');
+  }
+
+  /// Registers a compressor for both decompression and message encoding
+  /// negotiation.
   void register(Codec codec) {
     final encoding = codec.messageEncoding();
     assert(!encoding.contains(","),
         "Comma is currently not allowed in message encoding");
-    codecs[encoding] = codec;
+    if (!_codecs.containsKey(encoding)) {
+      _allSupportedCodecs.add(encoding);
+    }
+    _codecs[encoding] = codec;
   }
 }

--- a/lib/src/shared/codec_registry.dart
+++ b/lib/src/shared/codec_registry.dart
@@ -1,0 +1,21 @@
+import 'codec.dart';
+
+class CodecRegistry {
+  CodecRegistry() {
+    final allCodecs = [const Identity(), const Gzip()];
+    allCodecs.map((codec) => codecs[codec.getMessageEncoding()] = codec);
+  }
+
+  final Map<String, Codec> codecs = {};
+
+  Codec lookupCodec(String codecName) {
+    return codecs[codecName];
+  }
+
+  register(Codec codec) {
+    final encoding = codec.getMessageEncoding();
+    assert(!encoding.contains(","),
+        "Comma is currently not allowed in message encoding");
+    codecs[encoding] = codec;
+  }
+}

--- a/lib/src/shared/codec_registry.dart
+++ b/lib/src/shared/codec_registry.dart
@@ -11,6 +11,7 @@ class CodecRegistry {
     return CodecRegistry(codecs: []);
   }
 
+  /// Key refers to the `messageEncoding` string from the [Codec].
   final Map<String, Codec> _codecs = {};
   final List<String> _allSupportedCodecs = [];
 
@@ -22,7 +23,7 @@ class CodecRegistry {
     return _allSupportedCodecs.join(',');
   }
 
-  /// Registers a compressor for both decompression and message encoding
+  /// Registers a [Codec] for both decompression and message encoding
   /// negotiation.
   void register(Codec codec) {
     final encoding = codec.messageEncoding();

--- a/lib/src/shared/codec_registry.dart
+++ b/lib/src/shared/codec_registry.dart
@@ -1,37 +1,50 @@
+// Copyright (c) 2020, the gRPC project authors. Please see the AUTHORS file
+// for details. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'codec.dart';
 
 /// Encloses classes related to the compression and decompression of messages.
 class CodecRegistry {
-  CodecRegistry({List<Codec> codecs = const [const Identity()]})
-      : assert(codecs != null) {
-    codecs.forEach((codec) => register(codec));
+  CodecRegistry({List<Codec> codecs = const [const IdentityCodec()]})
+      : assert(codecs != null),
+        _codecs = Map.fromIterable(codecs, key: (c) => c.encodingName),
+        _supportedEncodings = codecs.map((c) {
+          if (c.encodingName.contains(',')) {
+            throw ArgumentError.value(c.encodingName, 'codecs',
+                'contains entries with names containing ","');
+          }
+          return c.encodingName;
+        }).join(',') {
+    if (_codecs.length != codecs.length) {
+      throw ArgumentError.value(
+          codecs, 'codecs', 'contains multiple entries with the same name');
+    }
   }
 
   factory CodecRegistry.empty() {
     return CodecRegistry(codecs: []);
   }
 
-  /// Key refers to the `messageEncoding` string from the [Codec].
-  final Map<String, Codec> _codecs = {};
-  final List<String> _allSupportedCodecs = [];
+  /// Key refers to the `encodingName` param from the [Codec].
+  final Map<String, Codec> _codecs;
 
-  Codec lookupCodec(String codecName) {
+  final String _supportedEncodings;
+
+  Codec lookup(String codecName) {
     return _codecs[codecName];
   }
 
-  String encodings() {
-    return _allSupportedCodecs.join(',');
-  }
-
-  /// Registers a [Codec] for both decompression and message encoding
-  /// negotiation.
-  void register(Codec codec) {
-    final encoding = codec.messageEncoding();
-    assert(!encoding.contains(","),
-        "Comma is currently not allowed in message encoding");
-    if (!_codecs.containsKey(encoding)) {
-      _allSupportedCodecs.add(encoding);
-    }
-    _codecs[encoding] = codec;
-  }
+  String get supportedEncodings => _supportedEncodings;
 }

--- a/lib/src/shared/codec_registry.dart
+++ b/lib/src/shared/codec_registry.dart
@@ -17,7 +17,7 @@ import 'codec.dart';
 
 /// Encloses classes related to the compression and decompression of messages.
 class CodecRegistry {
-  CodecRegistry({List<Codec> codecs = const [const IdentityCodec()]})
+  CodecRegistry({List<Codec> codecs = const [IdentityCodec()]})
       : assert(codecs != null),
         _codecs = Map.fromIterable(codecs, key: (c) => c.encodingName),
         _supportedEncodings = codecs.map((c) {

--- a/lib/src/shared/message.dart
+++ b/lib/src/shared/message.dart
@@ -57,8 +57,8 @@ class GrpcMessageSink extends Sink<GrpcMessage> {
   }
 }
 
-List<int> frame(List<int> payload, [Codec codec = const Identity()]) {
-  final compressedPayload = codec.compress(payload);
+List<int> frame(List<int> payload, [Codec codec]) {
+  final compressedPayload = codec == null ? payload : codec.compress(payload);
   final payloadLength = compressedPayload.length;
   final bytes = Uint8List(payloadLength + 5);
   final header = bytes.buffer.asByteData(0, 5);

--- a/lib/src/shared/message.dart
+++ b/lib/src/shared/message.dart
@@ -76,9 +76,8 @@ StreamTransformer<GrpcMessage, GrpcMessage> grpcDecompressor({
   Codec codec;
   return StreamTransformer<GrpcMessage, GrpcMessage>.fromHandlers(
       handleData: (GrpcMessage value, EventSink<GrpcMessage> sink) {
-    print(value);
     if (value is GrpcData && value.isCompressed) {
-      if (codec == null || codecRegistry.lookup(codec.encodingName) == null) {
+      if (codec == null) {
         sink.addError(
           GrpcError.unimplemented('Compression mechanism not supported'),
         );

--- a/lib/src/shared/message.dart
+++ b/lib/src/shared/message.dart
@@ -72,7 +72,7 @@ List<int> frame(List<int> rawPayload, [Codec codec]) {
 StreamTransformer<GrpcMessage, GrpcMessage> grpcDecompressor({
   CodecRegistry codecRegistry,
 }) {
-  Codec codec = const Identity();
+  Codec codec = const IdentityCodec();
   return StreamTransformer<GrpcMessage, GrpcMessage>.fromHandlers(
       handleData: (GrpcMessage value, EventSink<GrpcMessage> sink) {
     if (value is GrpcData && value.isCompressed) {
@@ -81,8 +81,8 @@ StreamTransformer<GrpcMessage, GrpcMessage> grpcDecompressor({
     }
 
     if (value is GrpcMetadata && value.metadata.containsKey('grpc-encoding')) {
-      codec = codecRegistry?.lookupCodec(value.metadata['grpc-encoding']) ??
-          const Identity();
+      codec = codecRegistry?.lookup(value.metadata['grpc-encoding']) ??
+          const IdentityCodec();
     }
     sink.add(value);
   });

--- a/lib/src/shared/message.dart
+++ b/lib/src/shared/message.dart
@@ -68,7 +68,9 @@ List<int> frame(List<int> payload, [Codec codec]) {
   return bytes;
 }
 
-StreamTransformer<GrpcMessage, GrpcMessage> grpcDecompressor() {
+StreamTransformer<GrpcMessage, GrpcMessage> grpcDecompressor({
+  CodecRegistry codecRegistry,
+}) {
   Codec codec = const Identity();
   return StreamTransformer<GrpcMessage, GrpcMessage>.fromHandlers(
       handleData: (GrpcMessage value, EventSink<GrpcMessage> sink) {
@@ -79,7 +81,8 @@ StreamTransformer<GrpcMessage, GrpcMessage> grpcDecompressor() {
       }
     } else if (value is GrpcMetadata &&
         value.metadata.containsKey('grpc-encoding')) {
-      codec = CodecRegistry().lookupCodec(value.metadata['grpc-encoding']);
+      codec = codecRegistry?.lookupCodec(value.metadata['grpc-encoding']) ??
+          const Identity();
     }
     sink.add(value);
   });

--- a/lib/src/shared/message.dart
+++ b/lib/src/shared/message.dart
@@ -55,7 +55,7 @@ class GrpcMessageSink extends Sink<GrpcMessage> {
   }
 }
 
-List<int> frame(List<int> payload, {Codec codec = const Identity()}) {
+List<int> frame(List<int> payload, [Codec codec = const Identity()]) {
   final compressedPayload = codec.compress(payload);
   final payloadLength = compressedPayload.length;
   final bytes = Uint8List(payloadLength + 5);
@@ -66,7 +66,8 @@ List<int> frame(List<int> payload, {Codec codec = const Identity()}) {
   return bytes;
 }
 
-StreamTransformer<GrpcMessage, GrpcMessage> grpcDecompressor({Codec codec = const Identity()}) =>
+StreamTransformer<GrpcMessage, GrpcMessage> grpcDecompressor(
+        [Codec codec = const Identity()]) =>
     StreamTransformer<GrpcMessage, GrpcMessage>.fromHandlers(
         handleData: (GrpcMessage value, EventSink<GrpcMessage> sink) {
       if (value is GrpcData) {

--- a/lib/src/shared/streams.dart
+++ b/lib/src/shared/streams.dart
@@ -19,10 +19,15 @@ import 'dart:typed_data';
 
 import 'package:http2/transport.dart';
 
+import 'codec.dart';
 import 'message.dart';
 import 'status.dart';
 
 class GrpcHttpEncoder extends Converter<GrpcMessage, StreamMessage> {
+  GrpcHttpEncoder([this.codec = const Identity()]) : assert(codec != null);
+
+  final Codec codec;
+
   @override
   StreamMessage convert(GrpcMessage input) {
     if (input is GrpcMetadata) {
@@ -32,13 +37,17 @@ class GrpcHttpEncoder extends Converter<GrpcMessage, StreamMessage> {
       });
       return HeadersStreamMessage(headers);
     } else if (input is GrpcData) {
-      return DataStreamMessage(frame(input.data));
+      return DataStreamMessage(frame(input.data, codec));
     }
     throw GrpcError.internal('Unexpected message type');
   }
 }
 
 class GrpcHttpDecoder extends Converter<StreamMessage, GrpcMessage> {
+  GrpcHttpDecoder([this.codec = const Identity()]) : assert(codec != null);
+
+  final Codec codec;
+
   @override
   GrpcMessage convert(StreamMessage input) {
     final sink = GrpcMessageSink();
@@ -50,18 +59,19 @@ class GrpcHttpDecoder extends Converter<StreamMessage, GrpcMessage> {
 
   @override
   Sink<StreamMessage> startChunkedConversion(Sink<GrpcMessage> sink) {
-    return _GrpcMessageConversionSink(sink);
+    return _GrpcMessageConversionSink(sink, codec);
   }
 }
 
 class _GrpcMessageConversionSink extends ChunkedConversionSink<StreamMessage> {
   final Sink<GrpcMessage> _out;
+  final Codec codec;
 
   final _dataHeader = Uint8List(5);
   Uint8List _data;
   int _dataOffset = 0;
 
-  _GrpcMessageConversionSink(this._out);
+  _GrpcMessageConversionSink(this._out, this.codec);
 
   void _addData(DataStreamMessage chunk) {
     final chunkData = chunk.bytes;
@@ -97,7 +107,7 @@ class _GrpcMessageConversionSink extends ChunkedConversionSink<StreamMessage> {
           chunkReadOffset += toCopy;
         }
         if (_dataOffset == _data.lengthInBytes) {
-          _out.add(GrpcData(_data,
+          _out.add(GrpcData(codec.decompress(_data),
               isCompressed: _dataHeader.buffer.asByteData().getUint8(0) != 0));
           _data = null;
           _dataOffset = 0;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: grpc
 description: Dart implementation of gRPC, a high performance, open-source universal RPC framework.
 
-version: 2.8.0
+version: 2.9.0-dev
 
 homepage: https://github.com/dart-lang/grpc-dart
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   sdk: '>=2.8.0 <3.0.0'
 
 dependencies:
+  archive: ^2.0.13
   async: ^2.2.0
   crypto: ^2.1.4
   fixnum: ^0.10.11

--- a/test/client_tests/client_test.dart
+++ b/test/client_tests/client_test.dart
@@ -63,6 +63,30 @@ void main() {
     );
   });
 
+  test('Unary calls attaches encoding headers', () async {
+    const requestValue = 17;
+    const responseValue = 19;
+
+    void handleRequest(StreamMessage message) {
+      final data = validateDataMessage(message);
+      expect(mockDecode(data.data), requestValue);
+
+      harness
+        ..sendResponseHeader()
+        ..sendResponseValue(responseValue)
+        ..sendResponseTrailer();
+    }
+
+    await harness.runTest(
+      clientCall: harness.client.unary(requestValue,
+          options: CallOptions(metadata: {'grpc-accept-encoding': 'gzip'})),
+      expectedResult: responseValue,
+      expectedCustomHeaders: {'grpc-accept-encoding': 'gzip'},
+      expectedPath: '/Test/Unary',
+      serverHandlers: [handleRequest],
+    );
+  });
+
   test('Client-streaming calls work on the client', () async {
     const requests = [17, 3];
     const response = 12;

--- a/test/client_tests/client_test.dart
+++ b/test/client_tests/client_test.dart
@@ -63,7 +63,7 @@ void main() {
     );
   });
 
-  test('Unary calls attaches encoding headers', () async {
+  test('Unary call attaches encoding headers', () async {
     const requestValue = 17;
     const responseValue = 19;
 

--- a/test/shared_tests/codec_registry_test.dart
+++ b/test/shared_tests/codec_registry_test.dart
@@ -5,14 +5,11 @@ import 'package:test/test.dart';
 void main() {
   test('CodecRegistry register adds new encodings', () {
     final registry = CodecRegistry();
-    expect(registry.encodings(), 'identity');
-
-    registry.register(const Gzip());
-    expect(registry.encodings(), 'identity,gzip');
+    expect(registry.supportedEncodings, 'identity');
   });
 
   test('CodecRegistry lookup', () {
     final registry = CodecRegistry();
-    expect(registry.lookupCodec('identity'), const Identity());
+    expect(registry.lookup('identity'), const IdentityCodec());
   });
 }

--- a/test/shared_tests/codec_registry_test.dart
+++ b/test/shared_tests/codec_registry_test.dart
@@ -1,0 +1,18 @@
+import 'package:grpc/src/shared/codec.dart';
+import 'package:grpc/src/shared/codec_registry.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('CodecRegistry register adds new encodings', () {
+    final registry = CodecRegistry();
+    expect(registry.encodings(), 'identity');
+
+    registry.register(const Gzip());
+    expect(registry.encodings(), 'identity,gzip');
+  });
+
+  test('CodecRegistry lookup', () {
+    final registry = CodecRegistry();
+    expect(registry.lookupCodec('identity'), const Identity());
+  });
+}

--- a/test/src/client_utils.dart
+++ b/test/src/client_utils.dart
@@ -68,7 +68,7 @@ class FakeChannelOptions implements ChannelOptions {
   Duration connectionTimeout = const Duration(seconds: 10);
   String userAgent = 'dart-grpc/1.0.0 test';
   BackoffStrategy backoffStrategy = testBackoff;
-  String codec = 'identity';
+  CodecRegistry codecRegistry = CodecRegistry.empty();
 }
 
 class FakeChannel extends ClientChannel {

--- a/test/src/client_utils.dart
+++ b/test/src/client_utils.dart
@@ -16,14 +16,13 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:grpc/grpc.dart';
 import 'package:grpc/src/client/channel.dart' as base;
 import 'package:grpc/src/client/http2_connection.dart';
 import 'package:grpc/src/shared/message.dart';
 import 'package:http2/transport.dart';
-import 'package:test/test.dart';
 import 'package:mockito/mockito.dart';
-
-import 'package:grpc/grpc.dart';
+import 'package:test/test.dart';
 
 import 'utils.dart';
 
@@ -69,6 +68,7 @@ class FakeChannelOptions implements ChannelOptions {
   Duration connectionTimeout = const Duration(seconds: 10);
   String userAgent = 'dart-grpc/1.0.0 test';
   BackoffStrategy backoffStrategy = testBackoff;
+  String codec = 'identity';
 }
 
 class FakeChannel extends ClientChannel {

--- a/test/src/server_utils.dart
+++ b/test/src/server_utils.dart
@@ -15,12 +15,11 @@
 
 import 'dart:async';
 
+import 'package:grpc/grpc.dart';
 import 'package:grpc/src/client/http2_connection.dart';
 import 'package:grpc/src/shared/message.dart';
 import 'package:http2/transport.dart';
 import 'package:test/test.dart';
-
-import 'package:grpc/grpc.dart';
 
 import 'utils.dart';
 
@@ -189,7 +188,7 @@ abstract class _Harness {
       Map<String, String> metadata,
       Duration timeout}) {
     final headers = Http2ClientConnection.createCallHeaders(
-        true, authority, path, timeout, metadata,
+        true, authority, path, timeout, metadata, null,
         userAgent: 'dart-grpc/1.0.0 test');
     toServer.add(HeadersStreamMessage(headers));
   }

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -15,8 +15,8 @@
 
 import 'dart:convert';
 
-import 'package:grpc/src/shared/streams.dart';
 import 'package:grpc/src/shared/message.dart';
+import 'package:grpc/src/shared/streams.dart';
 import 'package:http2/transport.dart';
 import 'package:test/test.dart';
 
@@ -44,7 +44,6 @@ void validateRequestHeaders(Map<String, String> headers,
   expect(headers['grpc-timeout'], timeout);
   expect(headers['content-type'], 'application/grpc');
   expect(headers['te'], 'trailers');
-  expect(headers['grpc-accept-encoding'], 'identity');
   expect(headers['user-agent'], startsWith('dart-grpc/'));
 
   customHeaders?.forEach((key, value) {


### PR DESCRIPTION
1. Add method level and server level compression and decompression.
2. Client can specify a comma separated encodings such as `gzip,identity` which is passed along in `grpc-accept-encoding` header.
3. server picks the first valid option from encodings that it can support and adds `grpc-encoding` in the response headers. 
4. Client decompresses the response body using the `grpc-encoding` in the header.