### PR TITLE
Allow to make future chain request with ResponseFuture

### DIFF
--- a/test/client_tests/client_interceptor_test.dart
+++ b/test/client_tests/client_interceptor_test.dart
@@ -1,7 +1,7 @@
 import 'package:grpc/grpc.dart';
 import 'package:grpc/src/client/interceptor.dart';
-import 'package:test/test.dart';
 import 'package:http2/transport.dart';
+import 'package:test/test.dart';
 
 import '../src/client_utils.dart';
 import '../src/utils.dart';
@@ -32,8 +32,14 @@ class FakeInterceptor implements ClientInterceptor {
   ResponseFuture<R> interceptUnary<Q, R>(ClientMethod<Q, R> method, Q request,
       CallOptions options, ClientUnaryInvoker<Q, R> invoker) {
     _invocations.add(InterceptorInvocation(_id, ++_unary, _streaming));
-
-    return invoker(method, request, _inject(options));
+    return ResponseFuture.wrap(
+            Future.delayed(Duration(seconds: 1), () => 'dummy'))
+        .then((_) => invoker(method, request, _inject(options)))
+        .then((foo) async => foo)
+        .whenComplete(() => 'complete')
+        .then((bar) => bar)
+        .catchError((e, s) => print('$e at $s'))
+        .timeout(Duration(seconds: 5));
   }
 
   @override


### PR DESCRIPTION
Closes #413

This PR allows to make future chain request with `ResponseFuture`:

```dart
  @override
  ResponseFuture<R> interceptUnary<Q, R>(ClientMethod<Q, R> method, Q request,
      CallOptions options, ClientUnaryInvoker<Q, R> invoker) {
    _invocations.add(InterceptorInvocation(_id, ++_unary, _streaming));
    return ResponseFuture.wrap(
            Future.delayed(Duration(seconds: 1), () => 'dummy'))
        .then((_) => invoker(method, request, _inject(options)))
        .then((foo) async => foo)
        .whenComplete(() => 'complete')
        .then((bar) => bar)
        .catchError((e, s) => print('$e at $s'))
        .timeout(Duration(seconds: 5));
  }
```