### PR TITLE
Migrate grpc to null safety

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -11,12 +11,12 @@ on:
 
 jobs:
   # Check code formating and static analysis on a single OS (linux)
-  # against Dart stable and dev.
+  # against Dart dev.
   analyze:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk: [stable, dev]
+        sdk: [dev]
     steps:
       - uses: actions/checkout@v2
       - uses: cedx/setup-dart@v2
@@ -43,7 +43,7 @@ jobs:
 
   # Run tests on a matrix consisting of three dimensions:
   # 1. OS: mac, windows, linux
-  # 2. release channel: stable, dev
+  # 2. release channel: dev
   # 3. TODO: Dart execution mode: native, web
   test:
     needs: analyze
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [stable, dev]
+        sdk: [dev]
         platform: [vm, chrome]
         exclude:
           # We only run Chrome tests on Linux. No need to run them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0-nullsafety.0
+
+* Migrate library and tests to null safety.
+
 ## 2.9.0
 
 * Added support for compression/decompression, which can be configured through

--- a/example/googleapis/pubspec.yaml
+++ b/example/googleapis/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   async: ^2.2.0
   grpc:
     path: ../../
-  protobuf: ^1.0.1
+  protobuf: ^2.0.0-nullsafety
 
 dev_dependencies:
   test: ^1.6.4

--- a/example/grpc-web/pubspec.yaml
+++ b/example/grpc-web/pubspec.yaml
@@ -8,8 +8,7 @@ environment:
 dependencies:
   grpc:
     path: ../../
-  protobuf: ^1.0.1
+  protobuf: ^2.0.0-nullsafety
 
 dev_dependencies:
   build_runner: ^1.5.2
-  build_web_compilers: ^2.1.1

--- a/example/helloworld/pubspec.yaml
+++ b/example/helloworld/pubspec.yaml
@@ -9,4 +9,4 @@ dependencies:
   async: ^2.2.0
   grpc:
     path: ../../
-  protobuf: ^1.0.1
+  protobuf: ^2.0.0-nullsafety

--- a/example/metadata/pubspec.yaml
+++ b/example/metadata/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   async: ^2.2.0
   grpc:
     path: ../../
-  protobuf: ^1.0.1
+  protobuf: ^2.0.0-nullsafety
 
 dev_dependencies:
   test: ^1.6.0

--- a/example/route_guide/pubspec.yaml
+++ b/example/route_guide/pubspec.yaml
@@ -9,4 +9,4 @@ dependencies:
   async: ^2.2.0
   grpc:
     path: ../../
-  protobuf: ^1.0.1
+  protobuf: ^2.0.0-nullsafety

--- a/interop/pubspec.yaml
+++ b/interop/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   collection: ^1.14.11
   grpc:
     path: ../
-  protobuf: ^1.0.1
+  protobuf: ^2.0.0-nullsafety
 
 dev_dependencies:
   test: ^1.6.4

--- a/lib/src/auth/rsa.dart
+++ b/lib/src/auth/rsa.dart
@@ -99,7 +99,7 @@ class ASN1Parser {
   static const SEQUENCE_TAG = 0x30;
 
   static ASN1Object parse(Uint8List bytes) {
-    invalidFormat(String msg) {
+    Never invalidFormat(String msg) {
       throw new ArgumentError("Invalid DER encoding: $msg");
     }
 
@@ -185,8 +185,6 @@ class ASN1Parser {
           invalidFormat(
               'Unexpected tag $tag at offset ${offset - 1} (end: $end).');
       }
-      // Unreachable.
-      return null;
     }
 
     final obj = decodeObject();

--- a/lib/src/client/channel.dart
+++ b/lib/src/client/channel.dart
@@ -44,8 +44,8 @@ abstract class ClientChannel {
 /// Auxiliary base class implementing much of ClientChannel.
 abstract class ClientChannelBase implements ClientChannel {
   // TODO(jakobr): Multiple connections, load balancing.
-  ClientConnection _connection;
-
+  late ClientConnection _connection;
+  var _connected = false;
   bool _isShutdown = false;
 
   ClientChannelBase();
@@ -54,13 +54,17 @@ abstract class ClientChannelBase implements ClientChannel {
   Future<void> shutdown() async {
     if (_isShutdown) return;
     _isShutdown = true;
-    if (_connection != null) await _connection.shutdown();
+    if (_connected) {
+      await _connection.shutdown();
+    }
   }
 
   @override
   Future<void> terminate() async {
     _isShutdown = true;
-    if (_connection != null) await _connection.terminate();
+    if (_connected) {
+      await _connection.terminate();
+    }
   }
 
   ClientConnection createConnection();
@@ -70,7 +74,11 @@ abstract class ClientChannelBase implements ClientChannel {
   /// The connection may be shared between multiple RPCs.
   Future<ClientConnection> getConnection() async {
     if (_isShutdown) throw GrpcError.unavailable('Channel shutting down.');
-    return _connection ??= createConnection();
+    if (!_connected) {
+      _connection = createConnection();
+      _connected = true;
+    }
+    return _connection;
   }
 
   @override

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -27,7 +27,7 @@ class Client {
 
   /// Interceptors will be applied in direct order before making a request.
   Client(this._channel,
-      {CallOptions options, Iterable<ClientInterceptor> interceptors})
+      {CallOptions? options, Iterable<ClientInterceptor>? interceptors})
       : _options = options ?? CallOptions(),
         _interceptors = List.unmodifiable(interceptors ?? Iterable.empty());
 
@@ -39,12 +39,12 @@ regenerate these stubs using  protobuf compiler plugin version 19.2.0 or newer.
 ''')
   ClientCall<Q, R> $createCall<Q, R>(
       ClientMethod<Q, R> method, Stream<Q> requests,
-      {CallOptions options}) {
+      {CallOptions? options}) {
     return _channel.createCall(method, requests, _options.mergedWith(options));
   }
 
   ResponseFuture<R> $createUnaryCall<Q, R>(ClientMethod<Q, R> method, Q request,
-      {CallOptions options}) {
+      {CallOptions? options}) {
     ClientUnaryInvoker<Q, R> invoker = (method, request, options) =>
         ResponseFuture<R>(
             _channel.createCall<Q, R>(method, Stream.value(request), options));
@@ -60,7 +60,7 @@ regenerate these stubs using  protobuf compiler plugin version 19.2.0 or newer.
 
   ResponseStream<R> $createStreamingCall<Q, R>(
       ClientMethod<Q, R> method, Stream<Q> requests,
-      {CallOptions options}) {
+      {CallOptions? options}) {
     ClientStreamingInvoker<Q, R> invoker = (method, request, options) =>
         ResponseStream<R>(_channel.createCall<Q, R>(method, requests, options));
 

--- a/lib/src/client/common.dart
+++ b/lib/src/client/common.dart
@@ -46,21 +46,21 @@ class ResponseFuture<R> extends DelegatingFuture<R>
     with _ResponseMixin<dynamic, R> {
   final ClientCall<dynamic, R> _call;
 
-  static R _ensureOnlyOneResponse<R>(R previous, R element) {
+  static R _ensureOnlyOneResponse<R>(R? previous, R element) {
     if (previous != null) {
       throw GrpcError.unimplemented('More than one response received');
     }
     return element;
   }
 
-  static R _ensureOneResponse<R>(R value) {
+  static R _ensureOneResponse<R>(R? value) {
     if (value == null) throw GrpcError.unimplemented('No responses received');
     return value;
   }
 
   ResponseFuture(this._call)
       : super(_call.response
-            .fold(null, _ensureOnlyOneResponse)
+            .fold<R?>(null, _ensureOnlyOneResponse)
             .then(_ensureOneResponse));
 }
 

--- a/lib/src/client/connection.dart
+++ b/lib/src/client/connection.dart
@@ -42,9 +42,9 @@ abstract class ClientConnection {
   void dispatchCall(ClientCall call);
 
   /// Start a request for [path] with [metadata].
-  GrpcTransportStream makeRequest(String path, Duration timeout,
+  GrpcTransportStream makeRequest(String path, Duration? timeout,
       Map<String, String> metadata, ErrorHandler onRequestFailure,
-      {CallOptions callOptions});
+      {required CallOptions callOptions});
 
   /// Shuts down this connection.
   ///

--- a/lib/src/client/interceptor.dart
+++ b/lib/src/client/interceptor.dart
@@ -3,10 +3,10 @@ import 'common.dart';
 import 'method.dart';
 
 typedef ClientUnaryInvoker<Q, R> = ResponseFuture<R> Function(
-    ClientMethod method, Q request, CallOptions options);
+    ClientMethod<Q, R> method, Q request, CallOptions options);
 
 typedef ClientStreamingInvoker<Q, R> = ResponseStream<R> Function(
-    ClientMethod method, Stream<Q> requests, CallOptions options);
+    ClientMethod<Q, R> method, Stream<Q> requests, CallOptions options);
 
 /// ClientInterceptors intercepts client calls before they are executed.
 ///

--- a/lib/src/client/options.dart
+++ b/lib/src/client/options.dart
@@ -26,7 +26,7 @@ const defaultIdleTimeout = Duration(minutes: 5);
 const defaultConnectionTimeOut = Duration(minutes: 50);
 const defaultUserAgent = 'dart-grpc/2.0.0';
 
-typedef Duration BackoffStrategy(Duration lastBackoff);
+typedef Duration BackoffStrategy(Duration? lastBackoff);
 
 // Backoff algorithm from https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md
 const _initialBackoff = Duration(seconds: 1);
@@ -35,7 +35,7 @@ const _multiplier = 1.6;
 const _jitter = 0.2;
 final _random = Random();
 
-Duration defaultBackoffStrategy(Duration lastBackoff) {
+Duration defaultBackoffStrategy(Duration? lastBackoff) {
   if (lastBackoff == null) return _initialBackoff;
   final jitter = _random.nextDouble() * 2 * _jitter - _jitter;
   final nextBackoff = lastBackoff * (_multiplier + jitter);
@@ -45,8 +45,8 @@ Duration defaultBackoffStrategy(Duration lastBackoff) {
 /// Options controlling how connections are made on a [ClientChannel].
 class ChannelOptions {
   final ChannelCredentials credentials;
-  final Duration idleTimeout;
-  final CodecRegistry codecRegistry;
+  final Duration? idleTimeout;
+  final CodecRegistry? codecRegistry;
 
   /// The maximum time a single connection will be used for new requests.
   final Duration connectionTimeout;

--- a/lib/src/client/query_parameter.dart
+++ b/lib/src/client/query_parameter.dart
@@ -29,17 +29,24 @@ class QueryParameter implements Comparable<QueryParameter> {
   String get value => values.first;
 
   /// Creates an instance by wrapping the single value in a [List].
-  QueryParameter(this.key, String value)
-      : assert(key != null && key.trim().isNotEmpty),
-        values = [value];
+  QueryParameter(this.key, String value) : values = [value] {
+    ArgumentError.checkNotNull(key);
+    if (key.trim().isEmpty) {
+      throw ArgumentError(key);
+    }
+  }
 
   /// Creates an instance from a [List] of values.
   ///
   /// This is not the default constructor since the single-value case is the
   /// most common.
   QueryParameter.multi(this.key, List<String> values)
-      : assert(key != null && key.trim().isNotEmpty),
-        values = values..sort();
+      : values = values..sort() {
+    ArgumentError.checkNotNull(key);
+    if (key.trim().isEmpty) {
+      throw ArgumentError(key);
+    }
+  }
 
   /// Returns the escaped value of the param as will appear in a URL.
   @override

--- a/lib/src/client/transport/http2_credentials.dart
+++ b/lib/src/client/transport/http2_credentials.dart
@@ -32,32 +32,32 @@ bool allowBadCertificates(X509Certificate certificate, String host) => true;
 /// Options controlling TLS security settings on a [ClientChannel].
 class ChannelCredentials {
   final bool isSecure;
-  final String authority;
-  final List<int> _certificateBytes;
-  final String _certificatePassword;
-  final BadCertificateHandler onBadCertificate;
+  final String? authority;
+  final List<int>? _certificateBytes;
+  final String? _certificatePassword;
+  final BadCertificateHandler? onBadCertificate;
 
   const ChannelCredentials._(this.isSecure, this._certificateBytes,
       this._certificatePassword, this.authority, this.onBadCertificate);
 
   /// Disable TLS. RPCs are sent in clear text.
-  const ChannelCredentials.insecure({String authority})
+  const ChannelCredentials.insecure({String? authority})
       : this._(false, null, null, authority, null);
 
   /// Enable TLS and optionally specify the [certificates] to trust. If
   /// [certificates] is not provided, the default trust store is used.
   const ChannelCredentials.secure(
-      {List<int> certificates,
-      String password,
-      String authority,
-      BadCertificateHandler onBadCertificate})
+      {List<int>? certificates,
+      String? password,
+      String? authority,
+      BadCertificateHandler? onBadCertificate})
       : this._(true, certificates, password, authority, onBadCertificate);
 
-  SecurityContext get securityContext {
+  SecurityContext? get securityContext {
     if (!isSecure) return null;
     if (_certificateBytes != null) {
       return createSecurityContext(false)
-        ..setTrustedCertificatesBytes(_certificateBytes,
+        ..setTrustedCertificatesBytes(_certificateBytes!,
             password: _certificatePassword);
     }
     final context = new SecurityContext(withTrustedRoots: true);

--- a/lib/src/client/transport/http2_transport.dart
+++ b/lib/src/client/transport/http2_transport.dart
@@ -15,9 +15,10 @@
 
 import 'dart:async';
 
-import 'package:grpc/grpc.dart';
 import 'package:http2/transport.dart';
 
+import '../../shared/codec.dart';
+import '../../shared/codec_registry.dart';
 import '../../shared/message.dart';
 import '../../shared/streams.dart';
 import 'transport.dart';
@@ -33,8 +34,8 @@ class Http2TransportStream extends GrpcTransportStream {
   Http2TransportStream(
     this._transportStream,
     this._onError,
-    CodecRegistry codecRegistry,
-    Codec compression,
+    CodecRegistry? codecRegistry,
+    Codec? compression,
   ) : incomingMessages = _transportStream.incomingMessages
             .transform(GrpcHttpDecoder())
             .transform(grpcDecompressor(codecRegistry: codecRegistry)) {

--- a/lib/src/client/transport/web_streams.dart
+++ b/lib/src/client/transport/web_streams.dart
@@ -47,10 +47,10 @@ class _GrpcWebConversionSink extends ChunkedConversionSink<ByteBuffer> {
   final _dataHeader = Uint8List(4);
 
   _GrpcWebParseState _state = _GrpcWebParseState.Init;
-  int _chunkOffset;
-  int _frameType;
-  int _dataOffset = 0;
-  Uint8List _data;
+  var _chunkOffset = 0;
+  int? _frameType;
+  var _dataOffset = 0;
+  Uint8List? _data;
 
   _GrpcWebConversionSink(this._out);
 
@@ -87,16 +87,16 @@ class _GrpcWebConversionSink extends ChunkedConversionSink<ByteBuffer> {
   }
 
   void _parseMessage(List<int> chunkData) {
-    final dataRemaining = _data.lengthInBytes - _dataOffset;
+    final dataRemaining = _data!.lengthInBytes - _dataOffset;
     if (dataRemaining > 0) {
       final chunkRemaining = chunkData.length - _chunkOffset;
       final toCopy = min(dataRemaining, chunkRemaining);
-      _data.setRange(
-          _dataOffset, _dataOffset + toCopy, chunkData, _chunkOffset);
+      _data!
+          .setRange(_dataOffset, _dataOffset + toCopy, chunkData, _chunkOffset);
       _dataOffset += toCopy;
       _chunkOffset += toCopy;
     }
-    if (_dataOffset == _data.lengthInBytes) {
+    if (_dataOffset == _data!.lengthInBytes) {
       _finishMessage();
     }
   }
@@ -104,10 +104,10 @@ class _GrpcWebConversionSink extends ChunkedConversionSink<ByteBuffer> {
   void _finishMessage() {
     switch (_frameType) {
       case frameTypeData:
-        _out.add(GrpcData(_data, isCompressed: false));
+        _out.add(GrpcData(_data!, isCompressed: false));
         break;
       case frameTypeTrailers:
-        final stringData = String.fromCharCodes(_data);
+        final stringData = String.fromCharCodes(_data!);
         final headers = _parseHttp1Headers(stringData);
         _out.add(GrpcMetadata(headers));
         break;
@@ -119,7 +119,7 @@ class _GrpcWebConversionSink extends ChunkedConversionSink<ByteBuffer> {
 
   Map<String, String> _parseHttp1Headers(String stringData) {
     final trimmed = stringData.trim();
-    final chunks = trimmed == '' ? [] : trimmed.split('\r\n');
+    final chunks = trimmed == '' ? <String>[] : trimmed.split('\r\n');
     final headers = <String, String>{};
     for (final chunk in chunks) {
       final pos = chunk.indexOf(':');

--- a/lib/src/client/transport/xhr_transport.dart
+++ b/lib/src/client/transport/xhr_transport.dart
@@ -51,7 +51,8 @@ class XhrTransportStream implements GrpcTransportStream {
   @override
   StreamSink<List<int>> get outgoingMessages => _outgoingMessages.sink;
 
-  XhrTransportStream(this._request, {onError, onDone})
+  XhrTransportStream(this._request,
+      {required ErrorHandler onError, required onDone})
       : _onError = onError,
         _onDone = onDone {
     _outgoingMessages.stream
@@ -170,7 +171,7 @@ class XhrClientConnection extends ClientConnection {
 
   void _initializeRequest(HttpRequest request, Map<String, String> metadata) {
     for (final header in metadata.keys) {
-      request.setRequestHeader(header, metadata[header]);
+      request.setRequestHeader(header, metadata[header]!);
     }
     // Overriding the mimetype allows us to stream and parse the data
     request.overrideMimeType('text/plain; charset=x-user-defined');
@@ -181,9 +182,9 @@ class XhrClientConnection extends ClientConnection {
   HttpRequest createHttpRequest() => HttpRequest();
 
   @override
-  GrpcTransportStream makeRequest(String path, Duration timeout,
+  GrpcTransportStream makeRequest(String path, Duration? timeout,
       Map<String, String> metadata, ErrorHandler onError,
-      {CallOptions callOptions}) {
+      {CallOptions? callOptions}) {
     // gRPC-web headers.
     if (_getContentTypeHeader(metadata) == null) {
       metadata['Content-Type'] = 'application/grpc-web+proto';
@@ -231,7 +232,7 @@ class XhrClientConnection extends ClientConnection {
   Future<void> shutdown() async {}
 }
 
-MapEntry<String, String> _getContentTypeHeader(Map<String, String> metadata) {
+MapEntry<String, String>? _getContentTypeHeader(Map<String, String> metadata) {
   for (var entry in metadata.entries) {
     if (entry.key.toLowerCase() == _contentTypeKey.toLowerCase()) {
       return entry;

--- a/lib/src/generated/google/protobuf/any.pb.dart
+++ b/lib/src/generated/google/protobuf/any.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: google/protobuf/any.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -37,7 +37,19 @@ class Any extends $pb.GeneratedMessage with $mixin.AnyMixin {
     ..hasRequiredFields = false;
 
   Any._() : super();
-  factory Any() => create();
+  factory Any({
+    $core.String? typeUrl,
+    $core.List<$core.int>? value,
+  }) {
+    final _result = create();
+    if (typeUrl != null) {
+      _result.typeUrl = typeUrl;
+    }
+    if (value != null) {
+      _result.value = value;
+    }
+    return _result;
+  }
   factory Any.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -51,8 +63,9 @@ class Any extends $pb.GeneratedMessage with $mixin.AnyMixin {
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
-  Any copyWith(void Function(Any) updates) => super.copyWith(
-      (message) => updates(message as Any)); // ignore: deprecated_member_use
+  Any copyWith(void Function(Any) updates) =>
+      super.copyWith((message) => updates(message as Any))
+          as Any; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Any create() => Any._();
@@ -61,7 +74,7 @@ class Any extends $pb.GeneratedMessage with $mixin.AnyMixin {
   @$core.pragma('dart2js:noInline')
   static Any getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Any>(create);
-  static Any _defaultInstance;
+  static Any? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get typeUrl => $_getSZ(0);

--- a/lib/src/generated/google/protobuf/any.pbenum.dart
+++ b/lib/src/generated/google/protobuf/any.pbenum.dart
@@ -2,5 +2,5 @@
 //  Generated code. Do not modify.
 //  source: google/protobuf/any.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields

--- a/lib/src/generated/google/protobuf/any.pbjson.dart
+++ b/lib/src/generated/google/protobuf/any.pbjson.dart
@@ -2,8 +2,10 @@
 //  Generated code. Do not modify.
 //  source: google/protobuf/any.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+
+import 'dart:core' as $core;
 
 const Any$json = const {
   '1': 'Any',

--- a/lib/src/generated/google/protobuf/duration.pb.dart
+++ b/lib/src/generated/google/protobuf/duration.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: google/protobuf/duration.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -38,7 +38,19 @@ class Duration extends $pb.GeneratedMessage with $mixin.DurationMixin {
     ..hasRequiredFields = false;
 
   Duration._() : super();
-  factory Duration() => create();
+  factory Duration({
+    $fixnum.Int64? seconds,
+    $core.int? nanos,
+  }) {
+    final _result = create();
+    if (seconds != null) {
+      _result.seconds = seconds;
+    }
+    if (nanos != null) {
+      _result.nanos = nanos;
+    }
+    return _result;
+  }
   factory Duration.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -53,8 +65,8 @@ class Duration extends $pb.GeneratedMessage with $mixin.DurationMixin {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   Duration copyWith(void Function(Duration) updates) =>
-      super.copyWith((message) =>
-          updates(message as Duration)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Duration))
+          as Duration; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Duration create() => Duration._();
@@ -63,7 +75,7 @@ class Duration extends $pb.GeneratedMessage with $mixin.DurationMixin {
   @$core.pragma('dart2js:noInline')
   static Duration getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Duration>(create);
-  static Duration _defaultInstance;
+  static Duration? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get seconds => $_getI64(0);

--- a/lib/src/generated/google/protobuf/duration.pbenum.dart
+++ b/lib/src/generated/google/protobuf/duration.pbenum.dart
@@ -2,5 +2,5 @@
 //  Generated code. Do not modify.
 //  source: google/protobuf/duration.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields

--- a/lib/src/generated/google/protobuf/duration.pbjson.dart
+++ b/lib/src/generated/google/protobuf/duration.pbjson.dart
@@ -2,8 +2,10 @@
 //  Generated code. Do not modify.
 //  source: google/protobuf/duration.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+
+import 'dart:core' as $core;
 
 const Duration$json = const {
   '1': 'Duration',

--- a/lib/src/generated/google/rpc/code.pb.dart
+++ b/lib/src/generated/google/rpc/code.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: google/rpc/code.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;

--- a/lib/src/generated/google/rpc/code.pbenum.dart
+++ b/lib/src/generated/google/rpc/code.pbenum.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: google/rpc/code.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 // ignore_for_file: UNDEFINED_SHOWN_NAME
@@ -115,7 +115,7 @@ class Code extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, Code> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static Code valueOf($core.int value) => _byValue[value];
+  static Code? valueOf($core.int value) => _byValue[value];
 
   const Code._($core.int v, $core.String n) : super(v, n);
 }

--- a/lib/src/generated/google/rpc/code.pbjson.dart
+++ b/lib/src/generated/google/rpc/code.pbjson.dart
@@ -2,8 +2,10 @@
 //  Generated code. Do not modify.
 //  source: google/rpc/code.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+
+import 'dart:core' as $core;
 
 const Code$json = const {
   '1': 'Code',

--- a/lib/src/generated/google/rpc/error_details.pb.dart
+++ b/lib/src/generated/google/rpc/error_details.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: google/rpc/error_details.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -30,7 +30,15 @@ class RetryInfo extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   RetryInfo._() : super();
-  factory RetryInfo() => create();
+  factory RetryInfo({
+    $1.Duration? retryDelay,
+  }) {
+    final _result = create();
+    if (retryDelay != null) {
+      _result.retryDelay = retryDelay;
+    }
+    return _result;
+  }
   factory RetryInfo.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -45,8 +53,8 @@ class RetryInfo extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   RetryInfo copyWith(void Function(RetryInfo) updates) =>
-      super.copyWith((message) =>
-          updates(message as RetryInfo)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as RetryInfo))
+          as RetryInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RetryInfo create() => RetryInfo._();
@@ -55,7 +63,7 @@ class RetryInfo extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static RetryInfo getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RetryInfo>(create);
-  static RetryInfo _defaultInstance;
+  static RetryInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $1.Duration get retryDelay => $_getN(0);
@@ -95,7 +103,19 @@ class DebugInfo extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   DebugInfo._() : super();
-  factory DebugInfo() => create();
+  factory DebugInfo({
+    $core.Iterable<$core.String>? stackEntries,
+    $core.String? detail,
+  }) {
+    final _result = create();
+    if (stackEntries != null) {
+      _result.stackEntries.addAll(stackEntries);
+    }
+    if (detail != null) {
+      _result.detail = detail;
+    }
+    return _result;
+  }
   factory DebugInfo.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -110,8 +130,8 @@ class DebugInfo extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   DebugInfo copyWith(void Function(DebugInfo) updates) =>
-      super.copyWith((message) =>
-          updates(message as DebugInfo)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as DebugInfo))
+          as DebugInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DebugInfo create() => DebugInfo._();
@@ -120,7 +140,7 @@ class DebugInfo extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static DebugInfo getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DebugInfo>(create);
-  static DebugInfo _defaultInstance;
+  static DebugInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.String> get stackEntries => $_getList(0);
@@ -161,7 +181,19 @@ class QuotaFailure_Violation extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   QuotaFailure_Violation._() : super();
-  factory QuotaFailure_Violation() => create();
+  factory QuotaFailure_Violation({
+    $core.String? subject,
+    $core.String? description,
+  }) {
+    final _result = create();
+    if (subject != null) {
+      _result.subject = subject;
+    }
+    if (description != null) {
+      _result.description = description;
+    }
+    return _result;
+  }
   factory QuotaFailure_Violation.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -178,8 +210,8 @@ class QuotaFailure_Violation extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   QuotaFailure_Violation copyWith(
           void Function(QuotaFailure_Violation) updates) =>
-      super.copyWith((message) => updates(
-          message as QuotaFailure_Violation)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as QuotaFailure_Violation))
+          as QuotaFailure_Violation; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static QuotaFailure_Violation create() => QuotaFailure_Violation._();
@@ -189,7 +221,7 @@ class QuotaFailure_Violation extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static QuotaFailure_Violation getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<QuotaFailure_Violation>(create);
-  static QuotaFailure_Violation _defaultInstance;
+  static QuotaFailure_Violation? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get subject => $_getSZ(0);
@@ -236,7 +268,15 @@ class QuotaFailure extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   QuotaFailure._() : super();
-  factory QuotaFailure() => create();
+  factory QuotaFailure({
+    $core.Iterable<QuotaFailure_Violation>? violations,
+  }) {
+    final _result = create();
+    if (violations != null) {
+      _result.violations.addAll(violations);
+    }
+    return _result;
+  }
   factory QuotaFailure.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -251,8 +291,8 @@ class QuotaFailure extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   QuotaFailure copyWith(void Function(QuotaFailure) updates) =>
-      super.copyWith((message) =>
-          updates(message as QuotaFailure)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as QuotaFailure))
+          as QuotaFailure; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static QuotaFailure create() => QuotaFailure._();
@@ -262,7 +302,7 @@ class QuotaFailure extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static QuotaFailure getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<QuotaFailure>(create);
-  static QuotaFailure _defaultInstance;
+  static QuotaFailure? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<QuotaFailure_Violation> get violations => $_getList(0);
@@ -300,7 +340,23 @@ class ErrorInfo extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   ErrorInfo._() : super();
-  factory ErrorInfo() => create();
+  factory ErrorInfo({
+    $core.String? reason,
+    $core.String? domain,
+    $core.Map<$core.String, $core.String>? metadata,
+  }) {
+    final _result = create();
+    if (reason != null) {
+      _result.reason = reason;
+    }
+    if (domain != null) {
+      _result.domain = domain;
+    }
+    if (metadata != null) {
+      _result.metadata.addAll(metadata);
+    }
+    return _result;
+  }
   factory ErrorInfo.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -315,8 +371,8 @@ class ErrorInfo extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   ErrorInfo copyWith(void Function(ErrorInfo) updates) =>
-      super.copyWith((message) =>
-          updates(message as ErrorInfo)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as ErrorInfo))
+          as ErrorInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ErrorInfo create() => ErrorInfo._();
@@ -325,7 +381,7 @@ class ErrorInfo extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static ErrorInfo getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ErrorInfo>(create);
-  static ErrorInfo _defaultInstance;
+  static ErrorInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get reason => $_getSZ(0);
@@ -383,7 +439,23 @@ class PreconditionFailure_Violation extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   PreconditionFailure_Violation._() : super();
-  factory PreconditionFailure_Violation() => create();
+  factory PreconditionFailure_Violation({
+    $core.String? type,
+    $core.String? subject,
+    $core.String? description,
+  }) {
+    final _result = create();
+    if (type != null) {
+      _result.type = type;
+    }
+    if (subject != null) {
+      _result.subject = subject;
+    }
+    if (description != null) {
+      _result.description = description;
+    }
+    return _result;
+  }
   factory PreconditionFailure_Violation.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -400,8 +472,9 @@ class PreconditionFailure_Violation extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   PreconditionFailure_Violation copyWith(
           void Function(PreconditionFailure_Violation) updates) =>
-      super.copyWith((message) => updates(message
-          as PreconditionFailure_Violation)); // ignore: deprecated_member_use
+      super.copyWith(
+              (message) => updates(message as PreconditionFailure_Violation))
+          as PreconditionFailure_Violation; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PreconditionFailure_Violation create() =>
@@ -412,7 +485,7 @@ class PreconditionFailure_Violation extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static PreconditionFailure_Violation getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PreconditionFailure_Violation>(create);
-  static PreconditionFailure_Violation _defaultInstance;
+  static PreconditionFailure_Violation? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get type => $_getSZ(0);
@@ -471,7 +544,15 @@ class PreconditionFailure extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   PreconditionFailure._() : super();
-  factory PreconditionFailure() => create();
+  factory PreconditionFailure({
+    $core.Iterable<PreconditionFailure_Violation>? violations,
+  }) {
+    final _result = create();
+    if (violations != null) {
+      _result.violations.addAll(violations);
+    }
+    return _result;
+  }
   factory PreconditionFailure.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -486,8 +567,8 @@ class PreconditionFailure extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   PreconditionFailure copyWith(void Function(PreconditionFailure) updates) =>
-      super.copyWith((message) => updates(
-          message as PreconditionFailure)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as PreconditionFailure))
+          as PreconditionFailure; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PreconditionFailure create() => PreconditionFailure._();
@@ -497,7 +578,7 @@ class PreconditionFailure extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static PreconditionFailure getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<PreconditionFailure>(create);
-  static PreconditionFailure _defaultInstance;
+  static PreconditionFailure? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<PreconditionFailure_Violation> get violations => $_getList(0);
@@ -526,7 +607,19 @@ class BadRequest_FieldViolation extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   BadRequest_FieldViolation._() : super();
-  factory BadRequest_FieldViolation() => create();
+  factory BadRequest_FieldViolation({
+    $core.String? field_1,
+    $core.String? description,
+  }) {
+    final _result = create();
+    if (field_1 != null) {
+      _result.field_1 = field_1;
+    }
+    if (description != null) {
+      _result.description = description;
+    }
+    return _result;
+  }
   factory BadRequest_FieldViolation.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -543,8 +636,8 @@ class BadRequest_FieldViolation extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   BadRequest_FieldViolation copyWith(
           void Function(BadRequest_FieldViolation) updates) =>
-      super.copyWith((message) => updates(message
-          as BadRequest_FieldViolation)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as BadRequest_FieldViolation))
+          as BadRequest_FieldViolation; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static BadRequest_FieldViolation create() => BadRequest_FieldViolation._();
@@ -554,7 +647,7 @@ class BadRequest_FieldViolation extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static BadRequest_FieldViolation getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<BadRequest_FieldViolation>(create);
-  static BadRequest_FieldViolation _defaultInstance;
+  static BadRequest_FieldViolation? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get field_1 => $_getSZ(0);
@@ -601,7 +694,15 @@ class BadRequest extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   BadRequest._() : super();
-  factory BadRequest() => create();
+  factory BadRequest({
+    $core.Iterable<BadRequest_FieldViolation>? fieldViolations,
+  }) {
+    final _result = create();
+    if (fieldViolations != null) {
+      _result.fieldViolations.addAll(fieldViolations);
+    }
+    return _result;
+  }
   factory BadRequest.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -616,8 +717,8 @@ class BadRequest extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   BadRequest copyWith(void Function(BadRequest) updates) =>
-      super.copyWith((message) =>
-          updates(message as BadRequest)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as BadRequest))
+          as BadRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static BadRequest create() => BadRequest._();
@@ -626,7 +727,7 @@ class BadRequest extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static BadRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<BadRequest>(create);
-  static BadRequest _defaultInstance;
+  static BadRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<BadRequest_FieldViolation> get fieldViolations => $_getList(0);
@@ -655,7 +756,19 @@ class RequestInfo extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   RequestInfo._() : super();
-  factory RequestInfo() => create();
+  factory RequestInfo({
+    $core.String? requestId,
+    $core.String? servingData,
+  }) {
+    final _result = create();
+    if (requestId != null) {
+      _result.requestId = requestId;
+    }
+    if (servingData != null) {
+      _result.servingData = servingData;
+    }
+    return _result;
+  }
   factory RequestInfo.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -670,8 +783,8 @@ class RequestInfo extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   RequestInfo copyWith(void Function(RequestInfo) updates) =>
-      super.copyWith((message) =>
-          updates(message as RequestInfo)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as RequestInfo))
+          as RequestInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static RequestInfo create() => RequestInfo._();
@@ -680,7 +793,7 @@ class RequestInfo extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static RequestInfo getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<RequestInfo>(create);
-  static RequestInfo _defaultInstance;
+  static RequestInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get requestId => $_getSZ(0);
@@ -737,7 +850,27 @@ class ResourceInfo extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   ResourceInfo._() : super();
-  factory ResourceInfo() => create();
+  factory ResourceInfo({
+    $core.String? resourceType,
+    $core.String? resourceName,
+    $core.String? owner,
+    $core.String? description,
+  }) {
+    final _result = create();
+    if (resourceType != null) {
+      _result.resourceType = resourceType;
+    }
+    if (resourceName != null) {
+      _result.resourceName = resourceName;
+    }
+    if (owner != null) {
+      _result.owner = owner;
+    }
+    if (description != null) {
+      _result.description = description;
+    }
+    return _result;
+  }
   factory ResourceInfo.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -752,8 +885,8 @@ class ResourceInfo extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   ResourceInfo copyWith(void Function(ResourceInfo) updates) =>
-      super.copyWith((message) =>
-          updates(message as ResourceInfo)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as ResourceInfo))
+          as ResourceInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ResourceInfo create() => ResourceInfo._();
@@ -763,7 +896,7 @@ class ResourceInfo extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static ResourceInfo getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ResourceInfo>(create);
-  static ResourceInfo _defaultInstance;
+  static ResourceInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get resourceType => $_getSZ(0);
@@ -837,7 +970,19 @@ class Help_Link extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   Help_Link._() : super();
-  factory Help_Link() => create();
+  factory Help_Link({
+    $core.String? description,
+    $core.String? url,
+  }) {
+    final _result = create();
+    if (description != null) {
+      _result.description = description;
+    }
+    if (url != null) {
+      _result.url = url;
+    }
+    return _result;
+  }
   factory Help_Link.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -852,8 +997,8 @@ class Help_Link extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   Help_Link copyWith(void Function(Help_Link) updates) =>
-      super.copyWith((message) =>
-          updates(message as Help_Link)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Help_Link))
+          as Help_Link; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Help_Link create() => Help_Link._();
@@ -862,7 +1007,7 @@ class Help_Link extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static Help_Link getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Help_Link>(create);
-  static Help_Link _defaultInstance;
+  static Help_Link? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get description => $_getSZ(0);
@@ -909,7 +1054,15 @@ class Help extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   Help._() : super();
-  factory Help() => create();
+  factory Help({
+    $core.Iterable<Help_Link>? links,
+  }) {
+    final _result = create();
+    if (links != null) {
+      _result.links.addAll(links);
+    }
+    return _result;
+  }
   factory Help.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -923,8 +1076,9 @@ class Help extends $pb.GeneratedMessage {
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
-  Help copyWith(void Function(Help) updates) => super.copyWith(
-      (message) => updates(message as Help)); // ignore: deprecated_member_use
+  Help copyWith(void Function(Help) updates) =>
+      super.copyWith((message) => updates(message as Help))
+          as Help; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Help create() => Help._();
@@ -933,7 +1087,7 @@ class Help extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static Help getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Help>(create);
-  static Help _defaultInstance;
+  static Help? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<Help_Link> get links => $_getList(0);
@@ -962,7 +1116,19 @@ class LocalizedMessage extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   LocalizedMessage._() : super();
-  factory LocalizedMessage() => create();
+  factory LocalizedMessage({
+    $core.String? locale,
+    $core.String? message,
+  }) {
+    final _result = create();
+    if (locale != null) {
+      _result.locale = locale;
+    }
+    if (message != null) {
+      _result.message = message;
+    }
+    return _result;
+  }
   factory LocalizedMessage.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -977,8 +1143,8 @@ class LocalizedMessage extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   LocalizedMessage copyWith(void Function(LocalizedMessage) updates) =>
-      super.copyWith((message) => updates(
-          message as LocalizedMessage)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as LocalizedMessage))
+          as LocalizedMessage; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LocalizedMessage create() => LocalizedMessage._();
@@ -988,7 +1154,7 @@ class LocalizedMessage extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static LocalizedMessage getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<LocalizedMessage>(create);
-  static LocalizedMessage _defaultInstance;
+  static LocalizedMessage? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get locale => $_getSZ(0);

--- a/lib/src/generated/google/rpc/error_details.pbenum.dart
+++ b/lib/src/generated/google/rpc/error_details.pbenum.dart
@@ -2,5 +2,5 @@
 //  Generated code. Do not modify.
 //  source: google/rpc/error_details.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields

--- a/lib/src/generated/google/rpc/error_details.pbjson.dart
+++ b/lib/src/generated/google/rpc/error_details.pbjson.dart
@@ -2,8 +2,10 @@
 //  Generated code. Do not modify.
 //  source: google/rpc/error_details.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+
+import 'dart:core' as $core;
 
 const RetryInfo$json = const {
   '1': 'RetryInfo',

--- a/lib/src/generated/google/rpc/status.pb.dart
+++ b/lib/src/generated/google/rpc/status.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: google/rpc/status.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -40,7 +40,23 @@ class Status extends $pb.GeneratedMessage {
         ..hasRequiredFields = false;
 
   Status._() : super();
-  factory Status() => create();
+  factory Status({
+    $core.int? code,
+    $core.String? message,
+    $core.Iterable<$0.Any>? details,
+  }) {
+    final _result = create();
+    if (code != null) {
+      _result.code = code;
+    }
+    if (message != null) {
+      _result.message = message;
+    }
+    if (details != null) {
+      _result.details.addAll(details);
+    }
+    return _result;
+  }
   factory Status.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -54,8 +70,9 @@ class Status extends $pb.GeneratedMessage {
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
-  Status copyWith(void Function(Status) updates) => super.copyWith(
-      (message) => updates(message as Status)); // ignore: deprecated_member_use
+  Status copyWith(void Function(Status) updates) =>
+      super.copyWith((message) => updates(message as Status))
+          as Status; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Status create() => Status._();
@@ -64,7 +81,7 @@ class Status extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static Status getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Status>(create);
-  static Status _defaultInstance;
+  static Status? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get code => $_getIZ(0);

--- a/lib/src/generated/google/rpc/status.pbenum.dart
+++ b/lib/src/generated/google/rpc/status.pbenum.dart
@@ -2,5 +2,5 @@
 //  Generated code. Do not modify.
 //  source: google/rpc/status.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields

--- a/lib/src/generated/google/rpc/status.pbjson.dart
+++ b/lib/src/generated/google/rpc/status.pbjson.dart
@@ -2,8 +2,10 @@
 //  Generated code. Do not modify.
 //  source: google/rpc/status.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+
+import 'dart:core' as $core;
 
 const Status$json = const {
   '1': 'Status',

--- a/lib/src/server/call.dart
+++ b/lib/src/server/call.dart
@@ -19,19 +19,19 @@
 /// ability to set custom metadata on the header/trailer sent to the client.
 abstract class ServiceCall {
   /// Custom metadata from the client.
-  Map<String, String> get clientMetadata;
+  Map<String, String>? get clientMetadata;
 
   /// Custom metadata to be sent to the client. Will be [null] once the headers
   /// have been sent, either when [sendHeaders] is called, or when the first
   /// response message is sent.
-  Map<String, String> get headers;
+  Map<String, String>? get headers;
 
   /// Custom metadata to be sent to the client after all response messages.
-  Map<String, String> get trailers;
+  Map<String, String>? get trailers;
 
   /// Deadline for this call. If the call is still active after this time, then
   /// the client or server may cancel it.
-  DateTime get deadline;
+  DateTime? get deadline;
 
   /// Returns [true] if the [deadline] has been exceeded.
   bool get isTimedOut;
@@ -50,5 +50,5 @@ abstract class ServiceCall {
   ///
   /// The call will be closed after calling this method, and no further
   /// responses can be sent.
-  void sendTrailers({int status, String message});
+  void sendTrailers({int? status, String? message});
 }

--- a/lib/src/server/interceptor.dart
+++ b/lib/src/server/interceptor.dart
@@ -10,5 +10,5 @@ import 'service.dart';
 /// If the interceptor returns a [GrpcError], the error will be returned as a response and [ServiceMethod] wouldn't be called.
 /// If the interceptor throws [Exception], [GrpcError.internal] with exception.toString() will be returned.
 /// If the interceptor returns null, the corresponding [ServiceMethod] of [Service] will be called.
-typedef Interceptor = FutureOr<GrpcError> Function(
+typedef Interceptor = FutureOr<GrpcError?> Function(
     ServiceCall call, ServiceMethod method);

--- a/lib/src/shared/codec.dart
+++ b/lib/src/shared/codec.dart
@@ -36,7 +36,7 @@ class IdentityCodec implements Codec {
   const IdentityCodec();
 
   @override
-  String get encodingName => "identity";
+  final encodingName = 'identity';
 
   @override
   List<int> compress(List<int> data) {
@@ -54,11 +54,11 @@ class GzipCodec implements Codec {
   const GzipCodec();
 
   @override
-  String get encodingName => "gzip";
+  final encodingName = "gzip";
 
   @override
   List<int> compress(List<int> data) {
-    return GZipEncoder().encode(data);
+    return GZipEncoder().encode(data)!;
   }
 
   @override

--- a/lib/src/shared/codec_registry.dart
+++ b/lib/src/shared/codec_registry.dart
@@ -18,8 +18,7 @@ import 'codec.dart';
 /// Encloses classes related to the compression and decompression of messages.
 class CodecRegistry {
   CodecRegistry({List<Codec> codecs = const [IdentityCodec()]})
-      : assert(codecs != null),
-        _codecs = Map.fromIterable(codecs, key: (c) => c.encodingName),
+      : _codecs = {for (var codec in codecs) codec.encodingName: codec},
         _supportedEncodings = codecs.map((c) {
           if (c.encodingName.contains(',')) {
             throw ArgumentError.value(c.encodingName, 'codecs',
@@ -33,16 +32,14 @@ class CodecRegistry {
     }
   }
 
-  factory CodecRegistry.empty() {
-    return CodecRegistry(codecs: []);
-  }
+  factory CodecRegistry.empty() => CodecRegistry(codecs: []);
 
   /// Key refers to the `encodingName` param from the [Codec].
   final Map<String, Codec> _codecs;
 
   final String _supportedEncodings;
 
-  Codec lookup(String codecName) {
+  Codec? lookup(String codecName) {
     return _codecs[codecName];
   }
 

--- a/lib/src/shared/profiler.dart
+++ b/lib/src/shared/profiler.dart
@@ -16,12 +16,12 @@
 import 'dart:developer';
 
 typedef TimelineTask TimelineTaskFactory(
-    {String filterKey, TimelineTask parent});
+    {String? filterKey, TimelineTask? parent});
 
 TimelineTaskFactory timelineTaskFactory = _defaultTimelineTaskFactory;
 
 TimelineTask _defaultTimelineTaskFactory(
-        {String filterKey, TimelineTask parent}) =>
+        {String? filterKey, TimelineTask? parent}) =>
     TimelineTask(filterKey: filterKey, parent: parent);
 
 const String clientTimelineFilterKey = 'grpc/client';

--- a/lib/src/shared/status.dart
+++ b/lib/src/shared/status.dart
@@ -125,9 +125,9 @@ class StatusCode {
 class GrpcError implements Exception {
   final int code;
   final String codeName;
-  final String message;
-  final List<GeneratedMessage> details;
-  final Object rawResponse;
+  final String? message;
+  final Object? rawResponse;
+  final List<GeneratedMessage>? details;
 
   /// Custom error code.
   GrpcError.custom(this.code, [this.message, this.details, this.rawResponse])

--- a/lib/src/shared/streams.dart
+++ b/lib/src/shared/streams.dart
@@ -58,7 +58,7 @@ class _GrpcMessageConversionSink extends ChunkedConversionSink<StreamMessage> {
   final Sink<GrpcMessage> _out;
 
   final _dataHeader = Uint8List(5);
-  Uint8List _data;
+  Uint8List? _data;
   int _dataOffset = 0;
 
   _GrpcMessageConversionSink(this._out);
@@ -87,17 +87,17 @@ class _GrpcMessageConversionSink extends ChunkedConversionSink<StreamMessage> {
       }
       if (_data != null) {
         // Reading data.
-        final dataRemaining = _data.lengthInBytes - _dataOffset;
+        final dataRemaining = _data!.lengthInBytes - _dataOffset;
         if (dataRemaining > 0) {
           final chunkRemaining = chunkLength - chunkReadOffset;
           final toCopy = min(dataRemaining, chunkRemaining);
-          _data.setRange(
+          _data!.setRange(
               _dataOffset, _dataOffset + toCopy, chunkData, chunkReadOffset);
           _dataOffset += toCopy;
           chunkReadOffset += toCopy;
         }
-        if (_dataOffset == _data.lengthInBytes) {
-          _out.add(GrpcData(_data,
+        if (_dataOffset == _data!.lengthInBytes) {
+          _out.add(GrpcData(_data!,
               isCompressed: _dataHeader.buffer.asByteData().getUint8(0) != 0));
           _data = null;
           _dataOffset = 0;

--- a/lib/src/shared/timeout.dart
+++ b/lib/src/shared/timeout.dart
@@ -17,7 +17,6 @@
 // Mostly inspired by grpc-java implementation.
 // TODO(jakobr): Modify to match grpc/core implementation instead.
 String toTimeoutString(Duration duration) {
-  if (duration == null) return null;
   const cutoff = 100000;
   final timeout = duration.inMicroseconds;
   if (timeout < 0) {
@@ -38,7 +37,7 @@ String toTimeoutString(Duration duration) {
 
 /// Convert [timeout] from grpc-timeout header string format to [Duration].
 /// Returns [null] if [timeout] is not correctly formatted.
-Duration fromTimeoutString(String timeout) {
+Duration? fromTimeoutString(String? timeout) {
   if (timeout == null) return null;
   if (timeout.length < 2) return null;
   final value = int.tryParse(timeout.substring(0, timeout.length - 1));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,28 +1,42 @@
 name: grpc
 description: Dart implementation of gRPC, a high performance, open-source universal RPC framework.
 
-version: 2.9.0
+version: 3.0.0-nullsafety.0
 
 homepage: https://github.com/dart-lang/grpc-dart
 
 environment:
-  sdk: '>=2.8.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
-  archive: ^2.0.13
+  archive: ^3.0.0-nullsafety
   async: ^2.2.0
-  crypto: ^2.1.4
-  fixnum: ^0.10.11
+  crypto: ^3.0.0-nullsafety
+  fixnum: ^1.0.0-nullsafety
   googleapis_auth: ^0.2.7
   meta: ^1.1.6
   http: ^0.12.0
-  http2: ^1.0.0
-  protobuf: ^1.0.1
+  http2: ^2.0.0-nullsafety
+  protobuf: ^2.0.0-nullsafety.1
 
 dev_dependencies:
-  build_runner: ^1.5.2
-  build_test: ^0.10.8
-  build_web_compilers: ^2.1.1
-  mockito: ^4.1.0
-  test: ^1.6.4
+  build_runner: ^1.11.0
+  build_test: ^1.3.4
+  mockito: ^5.0.0-nullsafety.5
+  test: ^1.16.0-nullsafety.16
   stream_channel: ^2.0.0
+  stream_transform: ^2.0.0-nullsafety
+
+dependency_overrides:
+  http:
+    git:
+      url: https://github.com/dart-lang/http.git
+      ref: 3845753a54624b070828cb3eff7a6c2a4e046cfb
+  googleapis_auth:
+    git:
+      url: https://github.com/dart-lang/googleapis_auth.git
+      ref: 30c084b7650fbd3e52525a127e0e65fc528e85a8
+  shelf:
+    git:
+      url: https://github.com/dart-lang/shelf.git
+      ref: 2102572a6c27b1321823bb3e3723ddb5448e04ae

--- a/test/client_handles_bad_connections_test.dart
+++ b/test/client_handles_bad_connections_test.dart
@@ -16,7 +16,7 @@ class TestClient extends grpc.Client {
       (List<int> value) => value[0]);
 
   TestClient(ClientChannel channel) : super(channel);
-  grpc.ResponseStream<int> stream(int request, {grpc.CallOptions options}) {
+  grpc.ResponseStream<int> stream(int request, {grpc.CallOptions? options}) {
     return $createStreamingCall(_$stream, Stream.value(request),
         options: options);
   }
@@ -56,7 +56,7 @@ main() async {
 
     final channel = FixedConnectionClientChannel(Http2ClientConnection(
       address,
-      server.port,
+      server.port!,
       grpc.ChannelOptions(
         idleTimeout: Duration(minutes: 1),
         // Short delay to test that it will time out.
@@ -84,7 +84,7 @@ main() async {
 
     final channel = FixedConnectionClientChannel(Http2ClientConnection(
         address,
-        server.port,
+        server.port!,
         grpc.ChannelOptions(credentials: grpc.ChannelCredentials.insecure())));
     final states = <grpc.ConnectionState>[];
     channel.clientConnection.onStateChanged =

--- a/test/client_tests/client_test.dart
+++ b/test/client_tests/client_test.dart
@@ -31,7 +31,7 @@ import '../src/utils.dart';
 void main() {
   const dummyValue = 0;
 
-  ClientHarness harness;
+  late ClientHarness harness;
 
   setUp(() {
     harness = ClientHarness()..setUp();
@@ -399,8 +399,8 @@ void main() {
 
   test('Connection errors are reported', () async {
     final connectionStates = <ConnectionState>[];
-    harness.connection.connectionError = 'Connection error';
-    harness.connection.onStateChanged = (connection) {
+    harness.connection!.connectionError = 'Connection error';
+    harness.connection!.onStateChanged = (connection) {
       final state = connection.state;
       connectionStates.add(state);
     };
@@ -418,7 +418,7 @@ void main() {
   test('Connections time out if idle', () async {
     final done = Completer();
     final connectionStates = <ConnectionState>[];
-    harness.connection.onStateChanged = (connection) {
+    harness.connection!.onStateChanged = (connection) {
       final state = connection.state;
       connectionStates.add(state);
       if (state == ConnectionState.idle) done.complete();
@@ -464,7 +464,7 @@ void main() {
         credentials: ChannelCredentials.insecure(authority: 'myauthority.com'));
     expect(Http2ClientConnection('localhost', 8080, channelOptions).authority,
         'myauthority.com');
-    expect(Http2ClientConnection('localhost', null, channelOptions).authority,
+    expect(Http2ClientConnection('localhost', 443, channelOptions).authority,
         'myauthority.com');
   });
 
@@ -481,12 +481,6 @@ void main() {
       'decodeStatusDetails should decode details into an empty list for an invalid base64 string',
       () {
     final decodedDetails = decodeStatusDetails('xxxxxxxxxxxxxxxxxxxxxx');
-    expect(decodedDetails, isA<List<GeneratedMessage>>());
-    expect(decodedDetails.length, 0);
-  });
-
-  test('decodeStatusDetails should handle a null input', () {
-    final decodedDetails = decodeStatusDetails(null);
     expect(decodedDetails, isA<List<GeneratedMessage>>());
     expect(decodedDetails.length, 0);
   });

--- a/test/client_tests/client_transport_connector_test.dart
+++ b/test/client_tests/client_transport_connector_test.dart
@@ -26,7 +26,7 @@ import '../src/utils.dart';
 void main() {
   const dummyValue = 0;
 
-  ClientTransportConnectorHarness harness;
+  late ClientTransportConnectorHarness harness;
 
   setUp(() {
     harness = ClientTransportConnectorHarness()..setUp();
@@ -349,8 +349,8 @@ void main() {
 
   test('Connection errors are reported', () async {
     final connectionStates = <ConnectionState>[];
-    harness.connection.connectionError = 'Connection error';
-    harness.connection.onStateChanged = (connection) {
+    harness.connection!.connectionError = 'Connection error';
+    harness.connection!.onStateChanged = (connection) {
       final state = connection.state;
       connectionStates.add(state);
     };
@@ -368,7 +368,7 @@ void main() {
   test('Connections time out if idle', () async {
     final done = Completer();
     final connectionStates = <ConnectionState>[];
-    harness.connection.onStateChanged = (connection) {
+    harness.connection!.onStateChanged = (connection) {
       final state = connection.state;
       connectionStates.add(state);
       if (state == ConnectionState.idle) done.complete();
@@ -414,7 +414,7 @@ void main() {
         credentials: ChannelCredentials.insecure(authority: 'myauthority.com'));
     expect(Http2ClientConnection('localhost', 8080, channelOptions).authority,
         'myauthority.com');
-    expect(Http2ClientConnection('localhost', null, channelOptions).authority,
+    expect(Http2ClientConnection('localhost', 443, channelOptions).authority,
         'myauthority.com');
   });
 }

--- a/test/connection_server_test.dart
+++ b/test/connection_server_test.dart
@@ -25,7 +25,7 @@ import 'src/server_utils.dart';
 void main() {
   const dummyValue = 17;
 
-  ConnectionServerHarness harness;
+  late ConnectionServerHarness harness;
 
   setUp(() {
     harness = ConnectionServerHarness()..setUp();
@@ -257,7 +257,7 @@ void main() {
     harness
       ..service.unaryHandler = methodHandler
       ..fromServer.stream.listen(expectAsync1((_) {}, count: 0),
-          onError: expectAsync1((error) {
+          onError: expectAsync1((dynamic error) {
             expect(error, 'TERMINATED');
           }, count: 1),
           onDone: expectAsync0(() {}, count: 1))

--- a/test/grpc_web_test.dart
+++ b/test/grpc_web_test.dart
@@ -11,7 +11,7 @@ import 'package:grpc/grpc_web.dart';
 import 'src/generated/echo.pbgrpc.dart';
 
 void main() {
-  GrpcWebServer server;
+  late GrpcWebServer server;
 
   setUpAll(() async {
     server = await GrpcWebServer.start();

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 @TestOn('vm')
+
 import 'dart:io';
 
 import 'package:grpc/src/client/transport/http2_credentials.dart';

--- a/test/round_trip_test.dart
+++ b/test/round_trip_test.dart
@@ -16,7 +16,7 @@ class TestClient extends Client {
       (int value) => [value], (List<int> value) => value[0]);
 
   TestClient(api.ClientChannel channel) : super(channel);
-  ResponseStream<int> stream(int request, {CallOptions options}) {
+  ResponseStream<int> stream(int request, {CallOptions? options}) {
     return $createStreamingCall(_$stream, Stream.value(request),
         options: options);
   }
@@ -66,7 +66,7 @@ main() async {
 
     final channel = FixedConnectionClientChannel(Http2ClientConnection(
       address,
-      server.port,
+      server.port!,
       ChannelOptions(credentials: ChannelCredentials.insecure()),
     ));
     final testClient = TestClient(channel);
@@ -83,7 +83,7 @@ main() async {
 
     final channel = FixedConnectionClientChannel(Http2ClientConnection(
       address,
-      server.port,
+      server.port!,
       ChannelOptions(
         credentials: ChannelCredentials.insecure(),
         codecRegistry: CodecRegistry(codecs: const [GzipCodec()]),
@@ -111,7 +111,7 @@ main() async {
 
     final channel = FixedConnectionClientChannel(Http2ClientConnection(
       address,
-      server.port,
+      server.port!,
       ChannelOptions(
           credentials: ChannelCredentials.secure(
               certificates: File('test/data/localhost.crt').readAsBytesSync(),
@@ -129,7 +129,7 @@ main() async {
 
     final channel = FixedConnectionClientChannel(Http2ClientConnection(
       'localhost',
-      server.port,
+      server.port!,
       ChannelOptions(credentials: ChannelCredentials.insecure()),
     ));
     final testClient = TestClient(channel);
@@ -145,7 +145,7 @@ main() async {
 
     final channel = FixedConnectionClientChannel(Http2ClientConnection(
       'localhost',
-      server.port,
+      server.port!,
       ChannelOptions(credentials: ChannelCredentials.insecure()),
     ));
     final testClient = TestClient(channel);

--- a/test/server_handles_broken_connection_test.dart
+++ b/test/server_handles_broken_connection_test.dart
@@ -14,7 +14,7 @@ class TestClient extends grpc.Client {
 
   TestClient(grpc.ClientChannel channel) : super(channel);
   grpc.ResponseStream<int> infiniteStream(int request,
-      {grpc.CallOptions options}) {
+      {grpc.CallOptions? options}) {
     return $createStreamingCall(_$infiniteStream, Stream.value(request),
         options: options);
   }
@@ -24,12 +24,13 @@ class TestService extends grpc.Service {
   String get $name => 'test.TestService';
   final void Function() finallyCallback;
 
-  TestService({this.finallyCallback}) {
+  TestService({required this.finallyCallback}) {
     $addMethod(grpc.ServiceMethod<int, int>('infiniteStream', infiniteStream,
         false, true, (List<int> value) => value[0], (int value) => [value]));
   }
 
-  Stream<int> infiniteStream(grpc.ServiceCall call, Future request) async* {
+  Stream<int> infiniteStream(
+      grpc.ServiceCall call, Future<int> request) async* {
     int count = await request;
     try {
       while (true) {
@@ -50,7 +51,8 @@ class ClientData {
   final InternetAddress address;
   final int port;
   final SendPort sendPort;
-  ClientData({this.address, this.port, this.sendPort});
+  ClientData(
+      {required this.address, required this.port, required this.sendPort});
 }
 
 void client(clientData) async {
@@ -73,7 +75,7 @@ main() async {
       "the client interrupting the connection does not crash the server",
       (address) async {
     // interrrupt the connect of client, the server does not crash.
-    grpc.Server server;
+    late grpc.Server server;
     server = grpc.Server([
       TestService(
           finallyCallback: expectAsync0(() {
@@ -86,7 +88,7 @@ main() async {
         client,
         ClientData(
             address: address,
-            port: server.port,
+            port: server.port!,
             sendPort: receivePort.sendPort));
     receivePort.listen(expectAsync1((e) {
       expect(e, isA<grpc.GrpcError>());

--- a/test/server_test.dart
+++ b/test/server_test.dart
@@ -25,7 +25,7 @@ import 'src/server_utils.dart';
 void main() {
   const dummyValue = 17;
 
-  ServerHarness harness;
+  late ServerHarness harness;
 
   setUp(() {
     harness = ServerHarness()..setUp();
@@ -271,7 +271,7 @@ void main() {
     harness
       ..service.unaryHandler = methodHandler
       ..fromServer.stream.listen(expectAsync1((_) {}, count: 0),
-          onError: expectAsync1((error) {
+          onError: expectAsync1((dynamic error) {
             expect(error, 'TERMINATED');
           }, count: 1),
           onDone: expectAsync0(() {}, count: 1))

--- a/test/src/client_utils.mocks.dart
+++ b/test/src/client_utils.mocks.dart
@@ -1,0 +1,91 @@
+import 'dart:async' as _i3;
+
+import 'package:http2/src/hpack/hpack.dart' as _i4;
+import 'package:http2/transport.dart' as _i2;
+import 'package:mockito/mockito.dart' as _i1;
+
+// ignore_for_file: comment_references
+
+// ignore_for_file: unnecessary_parenthesis
+
+class _FakeClientTransportStream extends _i1.Fake
+    implements _i2.ClientTransportStream {}
+
+class _FakeStreamSink<S> extends _i1.Fake implements _i3.StreamSink<S> {}
+
+/// A class which mocks [ClientTransportConnection].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockClientTransportConnection extends _i1.Mock
+    implements _i2.ClientTransportConnection {
+  MockClientTransportConnection() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  bool get isOpen =>
+      (super.noSuchMethod(Invocation.getter(#isOpen), false) as bool);
+  @override
+  set onActiveStateChanged(_i2.ActiveStateHandler? callback) =>
+      super.noSuchMethod(Invocation.setter(#onActiveStateChanged, callback));
+  @override
+  _i3.Future<void> get onInitialPeerSettingsReceived => (super.noSuchMethod(
+          Invocation.getter(#onInitialPeerSettingsReceived), Future.value(null))
+      as _i3.Future<void>);
+  @override
+  _i2.ClientTransportStream makeRequest(List<_i4.Header>? headers,
+          {bool? endStream = false}) =>
+      (super.noSuchMethod(
+          Invocation.method(#makeRequest, [headers], {#endStream: endStream}),
+          _FakeClientTransportStream()) as _i2.ClientTransportStream);
+  @override
+  _i3.Future<dynamic> ping() =>
+      (super.noSuchMethod(Invocation.method(#ping, []), Future.value(null))
+          as _i3.Future<dynamic>);
+  @override
+  _i3.Future<dynamic> finish() =>
+      (super.noSuchMethod(Invocation.method(#finish, []), Future.value(null))
+          as _i3.Future<dynamic>);
+  @override
+  _i3.Future<dynamic> terminate() =>
+      (super.noSuchMethod(Invocation.method(#terminate, []), Future.value(null))
+          as _i3.Future<dynamic>);
+}
+
+/// A class which mocks [ClientTransportStream].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockClientTransportStream extends _i1.Mock
+    implements _i2.ClientTransportStream {
+  MockClientTransportStream() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i3.Stream<_i2.TransportStreamPush> get peerPushes => (super.noSuchMethod(
+          Invocation.getter(#peerPushes),
+          Stream<_i2.TransportStreamPush>.empty())
+      as _i3.Stream<_i2.TransportStreamPush>);
+  @override
+  int get id => (super.noSuchMethod(Invocation.getter(#id), 0) as int);
+  @override
+  _i3.Stream<_i2.StreamMessage> get incomingMessages => (super.noSuchMethod(
+      Invocation.getter(#incomingMessages),
+      Stream<_i2.StreamMessage>.empty()) as _i3.Stream<_i2.StreamMessage>);
+  @override
+  _i3.StreamSink<_i2.StreamMessage> get outgoingMessages => (super.noSuchMethod(
+          Invocation.getter(#outgoingMessages),
+          _FakeStreamSink<_i2.StreamMessage>())
+      as _i3.StreamSink<_i2.StreamMessage>);
+  @override
+  set onTerminated(void Function(int?)? value) =>
+      super.noSuchMethod(Invocation.setter(#onTerminated, value));
+  @override
+  void sendHeaders(List<_i4.Header>? headers, {bool? endStream = false}) =>
+      super.noSuchMethod(
+          Invocation.method(#sendHeaders, [headers], {#endStream: endStream}));
+  @override
+  void sendData(List<int>? bytes, {bool? endStream = false}) =>
+      super.noSuchMethod(
+          Invocation.method(#sendData, [bytes], {#endStream: endStream}));
+}

--- a/test/src/generated/echo.pb.dart
+++ b/test/src/generated/echo.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: echo.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -27,7 +27,15 @@ class EchoRequest extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   EchoRequest._() : super();
-  factory EchoRequest() => create();
+  factory EchoRequest({
+    $core.String? message,
+  }) {
+    final _result = create();
+    if (message != null) {
+      _result.message = message;
+    }
+    return _result;
+  }
   factory EchoRequest.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -42,8 +50,8 @@ class EchoRequest extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   EchoRequest copyWith(void Function(EchoRequest) updates) =>
-      super.copyWith((message) =>
-          updates(message as EchoRequest)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as EchoRequest))
+          as EchoRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static EchoRequest create() => EchoRequest._();
@@ -52,7 +60,7 @@ class EchoRequest extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static EchoRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<EchoRequest>(create);
-  static EchoRequest _defaultInstance;
+  static EchoRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get message => $_getSZ(0);
@@ -85,7 +93,15 @@ class EchoResponse extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   EchoResponse._() : super();
-  factory EchoResponse() => create();
+  factory EchoResponse({
+    $core.String? message,
+  }) {
+    final _result = create();
+    if (message != null) {
+      _result.message = message;
+    }
+    return _result;
+  }
   factory EchoResponse.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -100,8 +116,8 @@ class EchoResponse extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   EchoResponse copyWith(void Function(EchoResponse) updates) =>
-      super.copyWith((message) =>
-          updates(message as EchoResponse)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as EchoResponse))
+          as EchoResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static EchoResponse create() => EchoResponse._();
@@ -111,7 +127,7 @@ class EchoResponse extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static EchoResponse getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<EchoResponse>(create);
-  static EchoResponse _defaultInstance;
+  static EchoResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get message => $_getSZ(0);
@@ -156,7 +172,23 @@ class ServerStreamingEchoRequest extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   ServerStreamingEchoRequest._() : super();
-  factory ServerStreamingEchoRequest() => create();
+  factory ServerStreamingEchoRequest({
+    $core.String? message,
+    $core.int? messageCount,
+    $core.int? messageInterval,
+  }) {
+    final _result = create();
+    if (message != null) {
+      _result.message = message;
+    }
+    if (messageCount != null) {
+      _result.messageCount = messageCount;
+    }
+    if (messageInterval != null) {
+      _result.messageInterval = messageInterval;
+    }
+    return _result;
+  }
   factory ServerStreamingEchoRequest.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -173,8 +205,9 @@ class ServerStreamingEchoRequest extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   ServerStreamingEchoRequest copyWith(
           void Function(ServerStreamingEchoRequest) updates) =>
-      super.copyWith((message) => updates(message
-          as ServerStreamingEchoRequest)); // ignore: deprecated_member_use
+      super.copyWith(
+              (message) => updates(message as ServerStreamingEchoRequest))
+          as ServerStreamingEchoRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ServerStreamingEchoRequest create() => ServerStreamingEchoRequest._();
@@ -184,7 +217,7 @@ class ServerStreamingEchoRequest extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static ServerStreamingEchoRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ServerStreamingEchoRequest>(create);
-  static ServerStreamingEchoRequest _defaultInstance;
+  static ServerStreamingEchoRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get message => $_getSZ(0);
@@ -241,7 +274,15 @@ class ServerStreamingEchoResponse extends $pb.GeneratedMessage {
     ..hasRequiredFields = false;
 
   ServerStreamingEchoResponse._() : super();
-  factory ServerStreamingEchoResponse() => create();
+  factory ServerStreamingEchoResponse({
+    $core.String? message,
+  }) {
+    final _result = create();
+    if (message != null) {
+      _result.message = message;
+    }
+    return _result;
+  }
   factory ServerStreamingEchoResponse.fromBuffer($core.List<$core.int> i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
@@ -258,8 +299,9 @@ class ServerStreamingEchoResponse extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   ServerStreamingEchoResponse copyWith(
           void Function(ServerStreamingEchoResponse) updates) =>
-      super.copyWith((message) => updates(message
-          as ServerStreamingEchoResponse)); // ignore: deprecated_member_use
+      super.copyWith(
+              (message) => updates(message as ServerStreamingEchoResponse))
+          as ServerStreamingEchoResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ServerStreamingEchoResponse create() =>
@@ -270,7 +312,7 @@ class ServerStreamingEchoResponse extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static ServerStreamingEchoResponse getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ServerStreamingEchoResponse>(create);
-  static ServerStreamingEchoResponse _defaultInstance;
+  static ServerStreamingEchoResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get message => $_getSZ(0);

--- a/test/src/generated/echo.pbenum.dart
+++ b/test/src/generated/echo.pbenum.dart
@@ -2,5 +2,5 @@
 //  Generated code. Do not modify.
 //  source: echo.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields

--- a/test/src/generated/echo.pbgrpc.dart
+++ b/test/src/generated/echo.pbgrpc.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: echo.proto
 //
-// @dart = 2.3
+
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:async' as $async;
@@ -26,18 +26,18 @@ class EchoServiceClient extends $grpc.Client {
           $0.ServerStreamingEchoResponse.fromBuffer(value));
 
   EchoServiceClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions options,
-      $core.Iterable<$grpc.ClientInterceptor> interceptors})
+      {$grpc.CallOptions? options,
+      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
   $grpc.ResponseFuture<$0.EchoResponse> echo($0.EchoRequest request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$echo, request, options: options);
   }
 
   $grpc.ResponseStream<$0.ServerStreamingEchoResponse> serverStreamingEcho(
       $0.ServerStreamingEchoRequest request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createStreamingCall(
         _$serverStreamingEcho, $async.Stream.fromIterable([request]),
         options: options);

--- a/test/src/generated/echo.pbjson.dart
+++ b/test/src/generated/echo.pbjson.dart
@@ -2,8 +2,10 @@
 //  Generated code. Do not modify.
 //  source: echo.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+
+import 'dart:core' as $core;
 
 const EchoRequest$json = const {
   '1': 'EchoRequest',

--- a/test/src/server_utils.dart
+++ b/test/src/server_utils.dart
@@ -27,12 +27,12 @@ class TestService extends Service {
   @override
   String get $name => 'Test';
 
-  Future<int> Function(ServiceCall call, Future<int> request) unaryHandler;
-  Future<int> Function(ServiceCall call, Stream<int> request)
+  Future<int> Function(ServiceCall call, Future<int> request)? unaryHandler;
+  Future<int> Function(ServiceCall call, Stream<int> request)?
       clientStreamingHandler;
-  Stream<int> Function(ServiceCall call, Future<int> request)
+  Stream<int> Function(ServiceCall call, Future<int> request)?
       serverStreamingHandler;
-  Stream<int> Function(ServiceCall call, Stream<int> request)
+  Stream<int> Function(ServiceCall call, Stream<int> request)?
       bidirectionalHandler;
 
   TestService() {
@@ -53,40 +53,40 @@ class TestService extends Service {
     if (unaryHandler == null) {
       fail('Should not invoke Unary');
     }
-    return unaryHandler(call, request);
+    return unaryHandler!(call, request);
   }
 
   Future<int> _clientStreaming(ServiceCall call, Stream<int> request) {
     if (clientStreamingHandler == null) {
       fail('Should not invoke ClientStreaming');
     }
-    return clientStreamingHandler(call, request);
+    return clientStreamingHandler!(call, request);
   }
 
   Stream<int> _serverStreaming(ServiceCall call, Future<int> request) {
     if (serverStreamingHandler == null) {
       fail('Should not invoke ServerStreaming');
     }
-    return serverStreamingHandler(call, request);
+    return serverStreamingHandler!(call, request);
   }
 
   Stream<int> _bidirectional(ServiceCall call, Stream<int> request) {
     if (bidirectionalHandler == null) {
       fail('Should not invoke Bidirectional');
     }
-    return bidirectionalHandler(call, request);
+    return bidirectionalHandler!(call, request);
   }
 }
 
 class TestInterceptor {
-  Interceptor handler;
+  Interceptor? handler;
 
-  FutureOr<GrpcError> call(ServiceCall call, ServiceMethod method) {
+  FutureOr<GrpcError?> call(ServiceCall call, ServiceMethod method) {
     if (handler == null) {
       return null;
     }
 
-    return handler(call, method);
+    return handler!(call, method);
   }
 }
 
@@ -112,7 +112,8 @@ class TestServerStream extends ServerTransportStream {
   bool get canPush => true;
 
   @override
-  ServerTransportStream push(List<Header> requestHeaders) => null;
+  ServerTransportStream push(List<Header> requestHeaders) =>
+      throw 'unimplemented';
 }
 
 class ServerHarness extends _Harness {
@@ -144,7 +145,7 @@ abstract class _Harness {
   final fromServer = StreamController<StreamMessage>();
   final service = TestService();
   final interceptor = TestInterceptor();
-  ConnectionServer _server;
+  ConnectionServer? _server;
 
   ConnectionServer createServer();
 
@@ -168,7 +169,7 @@ abstract class _Harness {
 
     fromServer.stream.listen(
         expectAsync1(handleMessages, count: handlers.length),
-        onError: expectAsync1((_) {}, count: 0),
+        onError: expectAsync1((dynamic _) {}, count: 0),
         onDone: expectAsync0(() {}, count: 1));
   }
 
@@ -185,8 +186,8 @@ abstract class _Harness {
 
   void sendRequestHeader(String path,
       {String authority = 'test',
-      Map<String, String> metadata,
-      Duration timeout}) {
+      Map<String, String>? metadata,
+      Duration? timeout}) {
     final headers = Http2ClientConnection.createCallHeaders(
         true, authority, path, timeout, metadata, null,
         userAgent: 'dart-grpc/1.0.0 test');

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -31,10 +31,10 @@ Map<String, String> headersToMap(List<Header> headers) =>
         key: (h) => ascii.decode(h.name), value: (h) => ascii.decode(h.value));
 
 void validateRequestHeaders(Map<String, String> headers,
-    {String path,
+    {String? path,
     String authority = 'test',
-    String timeout,
-    Map<String, String> customHeaders}) {
+    String? timeout,
+    Map<String, String>? customHeaders}) {
   expect(headers[':method'], 'POST');
   expect(headers[':scheme'], 'https');
   if (path != null) {
@@ -54,7 +54,7 @@ void validateRequestHeaders(Map<String, String> headers,
 void validateResponseHeaders(Map<String, String> headers,
     {int status = 200,
     bool allowTrailers = false,
-    Map<String, String> customHeaders}) {
+    Map<String, String>? customHeaders}) {
   expect(headers[':status'], '200');
   expect(headers['content-type'], startsWith('application/grpc'));
   if (!allowTrailers) {
@@ -67,7 +67,7 @@ void validateResponseHeaders(Map<String, String> headers,
 }
 
 void validateResponseTrailers(Map<String, String> trailers,
-    {int status = 0, String message, Map<String, String> customTrailers}) {
+    {int status = 0, String? message, Map<String, String>? customTrailers}) {
   expect(trailers['grpc-status'], '$status');
   if (message != null) {
     expect(trailers['grpc-message'], message);
@@ -84,7 +84,7 @@ GrpcMetadata validateMetadataMessage(StreamMessage message,
 
   final decoded = GrpcHttpDecoder().convert(message);
   expect(decoded, TypeMatcher<GrpcMetadata>());
-  return decoded;
+  return decoded as GrpcMetadata;
 }
 
 GrpcData validateDataMessage(StreamMessage message, {bool endStream = false}) {
@@ -93,7 +93,7 @@ GrpcData validateDataMessage(StreamMessage message, {bool endStream = false}) {
 
   final decoded = GrpcHttpDecoder().convert(message);
   expect(decoded, TypeMatcher<GrpcData>());
-  return decoded;
+  return decoded as GrpcData;
 }
 
 void Function(StreamMessage message) headerValidator() {

--- a/test/stream_test.dart
+++ b/test/stream_test.dart
@@ -22,8 +22,8 @@ import 'package:grpc/grpc.dart';
 
 void main() {
   group('GrpcHttpDecoder', () {
-    StreamController<StreamMessage> input;
-    Stream<GrpcMessage> output;
+    late StreamController<StreamMessage> input;
+    late Stream<GrpcMessage> output;
 
     setUp(() {
       input = StreamController();
@@ -51,11 +51,12 @@ void main() {
       }
 
       expect(converted[0], TypeMatcher<GrpcMetadata>());
-      verify(converted[1], [48, 49, 50, 51, 52, 53, 54, 55, 56, 57]);
-      verify(converted[2], [97, 98, 99, 100]);
-      verify(converted[3], [65]);
-      verify(converted[4], [48, 49, 50, 51]);
-      verify(converted[5], List.filled(256, 90));
+      verify(
+          converted[1] as GrpcData, [48, 49, 50, 51, 52, 53, 54, 55, 56, 57]);
+      verify(converted[2] as GrpcData, [97, 98, 99, 100]);
+      verify(converted[3] as GrpcData, [65]);
+      verify(converted[4] as GrpcData, [48, 49, 50, 51]);
+      verify(converted[5] as GrpcData, List.filled(256, 90));
     });
 
     test('throws error if input is closed while receiving data header',

--- a/test/timeline_test.dart
+++ b/test/timeline_test.dart
@@ -33,7 +33,7 @@ class TestClient extends Client {
       path, (int value) => [value], (List<int> value) => value[0]);
 
   TestClient(api.ClientChannel channel) : super(channel);
-  ResponseStream<int> stream(int request, {CallOptions options}) {
+  ResponseStream<int> stream(int request, {CallOptions? options}) {
     return $createStreamingCall(_$stream, Stream.fromIterable([request]),
         options: options);
   }
@@ -69,12 +69,12 @@ class FakeTimelineTask extends Fake implements TimelineTask {
   static final List<Map> events = [];
   static int _idCount = 0;
 
-  final String filterKey;
-  final TimelineTask parent;
+  final String? filterKey;
+  final TimelineTask? parent;
   final int id = _idCount++;
   int _startFinishCount = 0;
 
-  factory FakeTimelineTask({TimelineTask parent, String filterKey}) {
+  factory FakeTimelineTask({TimelineTask? parent, String? filterKey}) {
     final task = FakeTimelineTask._(parent: parent, filterKey: filterKey);
     tasks.add(task);
     return task;
@@ -84,7 +84,7 @@ class FakeTimelineTask extends Fake implements TimelineTask {
 
   bool get isComplete => _startFinishCount == 0;
 
-  void start(String name, {Map arguments}) {
+  void start(String name, {Map? arguments}) {
     events.add({
       'id': id,
       'ph': 'b',
@@ -98,7 +98,7 @@ class FakeTimelineTask extends Fake implements TimelineTask {
     ++_startFinishCount;
   }
 
-  void instant(String name, {Map arguments}) {
+  void instant(String name, {Map? arguments}) {
     events.add({
       'id': id,
       'ph': 'i',
@@ -110,7 +110,7 @@ class FakeTimelineTask extends Fake implements TimelineTask {
     });
   }
 
-  void finish({Map arguments}) {
+  void finish({Map? arguments}) {
     events.add({
       'id': id,
       'ph': 'e',
@@ -124,7 +124,8 @@ class FakeTimelineTask extends Fake implements TimelineTask {
   }
 }
 
-TimelineTask fakeTimelineTaskFactory({String filterKey, TimelineTask parent}) =>
+TimelineTask fakeTimelineTaskFactory(
+        {String? filterKey, TimelineTask? parent}) =>
     FakeTimelineTask(filterKey: filterKey, parent: parent);
 
 testee() async {
@@ -134,7 +135,7 @@ testee() async {
   timelineTaskFactory = fakeTimelineTaskFactory;
   final channel = FixedConnectionClientChannel(Http2ClientConnection(
     'localhost',
-    server.port,
+    server.port!,
     ChannelOptions(credentials: ChannelCredentials.insecure()),
   ));
   final testClient = TestClient(channel);


### PR DESCRIPTION
Based on an internal change which
- Some of the required dependencies are not published yet, so using dependency overrides
- I could not find compatible `build_web_compilers` package version because of bazel_worker, so I have dropped this dependency (I guess it is needed to run tests with DDC)
- Some of the migrated code could be handled more elegantly to reduce the number of `!`/`?` in implementation, but currently internal and external versions are slightly out of sync so I tried to minimize the changes to make merging easier 