### PR TITLE
Update interop to null-safe grpc-dart

### DIFF
--- a/example/grpc-web/pubspec.yaml
+++ b/example/grpc-web/pubspec.yaml
@@ -18,3 +18,5 @@ dependency_overrides:
   # TODO: Need bazel_worker 1.0.0-nullsafety.0 published
   bazel_worker:
     git: https://github.com/dart-lang/bazel_worker
+  shelf:
+    version: ^1.0.0-nullsafety

--- a/interop/bin/client.dart
+++ b/interop/bin/client.dart
@@ -88,19 +88,24 @@ Future<int> main(List<String> args) async {
           'developer console.');
   final arguments = argumentParser.parse(args);
 
-  final testClient = Tester();
-
-  testClient.serverHost = arguments[_serverHostArgument];
-  testClient.serverHostOverride = arguments[_serverHostOverrideArgument];
-  testClient.serverPort = arguments[_serverPortArgument];
-  testClient.testCase = arguments[_testCaseArgument];
-  testClient.useTls = arguments[_useTLSArgument];
-  testClient.useTestCA = arguments[_useTestCAArgument];
-  testClient.defaultServiceAccount = arguments[_defaultServiceAccountArgument];
-  testClient.oauthScope = arguments[_oauthScopeArgument];
-  testClient.serviceAccountKeyFile = arguments[_serviceAccountKeyFileArgument];
-
-  if (!testClient.validate()) {
+  late Tester testClient;
+  try {
+    testClient = Tester(
+        serverHost: arguments[_serverHostArgument] ??
+            (throw 'Must specify --$_serverHostArgument'),
+        serverHostOverride: arguments[_serverHostOverrideArgument],
+        serverPort: int.tryParse(arguments[_serverPortArgument] ??
+                (throw 'Must specify --$_serverPortArgument')) ??
+            (throw 'Invalid port "${arguments[_serverPortArgument]}"'),
+        testCase: arguments[_testCaseArgument] ??
+            (throw 'Must specify --$_testCaseArgument'),
+        useTls: arguments[_useTLSArgument] != 'false',
+        useTestCA: arguments[_useTestCAArgument],
+        defaultServiceAccount: arguments[_defaultServiceAccountArgument],
+        oauthScope: arguments[_oauthScopeArgument],
+        serviceAccountKeyFile: arguments[_serviceAccountKeyFileArgument]);
+  } catch (e) {
+    print(e);
     print(argumentParser.usage);
     return -1;
   }

--- a/interop/bin/server.dart
+++ b/interop/bin/server.dart
@@ -30,13 +30,13 @@ const _trailerEchoKey = 'x-grpc-test-echo-trailing-bin';
 class TestService extends TestServiceBase {
   @override
   void $onMetadata(ServiceCall context) {
-    final headerEcho = context.clientMetadata[_headerEchoKey];
+    final headerEcho = context.clientMetadata![_headerEchoKey];
     if (headerEcho != null) {
-      context.headers[_headerEchoKey] = headerEcho;
+      context.headers![_headerEchoKey] = headerEcho;
     }
-    final trailerEcho = context.clientMetadata[_trailerEchoKey];
+    final trailerEcho = context.clientMetadata![_trailerEchoKey];
     if (trailerEcho != null) {
-      context.trailers[_trailerEchoKey] = trailerEcho;
+      context.trailers![_trailerEchoKey] = trailerEcho;
     }
   }
 
@@ -67,7 +67,7 @@ class TestService extends TestServiceBase {
   @override
   Future<StreamingInputCallResponse> streamingInputCall(
       ServiceCall call, Stream<StreamingInputCallRequest> request) async {
-    final aggregatedPayloadSize = await request.fold(
+    final aggregatedPayloadSize = await request.fold<int>(
         0, (size, message) => size + message.payload.body.length);
     return StreamingInputCallResponse()
       ..aggregatedPayloadSize = aggregatedPayloadSize;
@@ -114,9 +114,9 @@ class TestService extends TestServiceBase {
   }
 
   @override
-  Future<Empty> unimplementedCall(ServiceCall call, Empty request) {
+  Future<Empty> unimplementedCall(ServiceCall call, Empty request) async {
     call.sendTrailers(status: StatusCode.unimplemented);
-    return null;
+    return Empty();
   }
 }
 
@@ -133,7 +133,7 @@ Future<void> main(List<String> args) async {
 
   final server = Server(services);
 
-  ServerTlsCredentials tlsCredentials;
+  late ServerTlsCredentials tlsCredentials;
   if (arguments['use_tls'] == 'true') {
     final certificate = File(arguments['tls_cert_file']).readAsBytes();
     final privateKey = File(arguments['tls_key_file']).readAsBytes();

--- a/interop/lib/src/generated/empty.pb.dart
+++ b/interop/lib/src/generated/empty.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: empty.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -36,8 +36,9 @@ class Empty extends $pb.GeneratedMessage {
   @$core.Deprecated('Using this can add significant overhead to your binary. '
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
-  Empty copyWith(void Function(Empty) updates) => super.copyWith(
-      (message) => updates(message as Empty)); // ignore: deprecated_member_use
+  Empty copyWith(void Function(Empty) updates) =>
+      super.copyWith((message) => updates(message as Empty))
+          as Empty; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Empty create() => Empty._();
@@ -46,5 +47,5 @@ class Empty extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static Empty getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Empty>(create);
-  static Empty _defaultInstance;
+  static Empty? _defaultInstance;
 }

--- a/interop/lib/src/generated/messages.pb.dart
+++ b/interop/lib/src/generated/messages.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: messages.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -32,7 +32,7 @@ class BoolValue extends $pb.GeneratedMessage {
 
   BoolValue._() : super();
   factory BoolValue({
-    $core.bool value,
+    $core.bool? value,
   }) {
     final _result = create();
     if (value != null) {
@@ -54,8 +54,8 @@ class BoolValue extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   BoolValue copyWith(void Function(BoolValue) updates) =>
-      super.copyWith((message) =>
-          updates(message as BoolValue)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as BoolValue))
+          as BoolValue; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static BoolValue create() => BoolValue._();
@@ -64,7 +64,7 @@ class BoolValue extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static BoolValue getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BoolValue>(create);
-  static BoolValue _defaultInstance;
+  static BoolValue? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get value => $_getBF(0);
@@ -106,8 +106,8 @@ class Payload extends $pb.GeneratedMessage {
 
   Payload._() : super();
   factory Payload({
-    PayloadType type,
-    $core.List<$core.int> body,
+    PayloadType? type,
+    $core.List<$core.int>? body,
   }) {
     final _result = create();
     if (type != null) {
@@ -132,8 +132,8 @@ class Payload extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   Payload copyWith(void Function(Payload) updates) =>
-      super.copyWith((message) =>
-          updates(message as Payload)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Payload))
+          as Payload; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Payload create() => Payload._();
@@ -142,7 +142,7 @@ class Payload extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static Payload getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Payload>(create);
-  static Payload _defaultInstance;
+  static Payload? _defaultInstance;
 
   @$pb.TagNumber(1)
   PayloadType get type => $_getN(0);
@@ -194,8 +194,8 @@ class EchoStatus extends $pb.GeneratedMessage {
 
   EchoStatus._() : super();
   factory EchoStatus({
-    $core.int code,
-    $core.String message,
+    $core.int? code,
+    $core.String? message,
   }) {
     final _result = create();
     if (code != null) {
@@ -220,8 +220,8 @@ class EchoStatus extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   EchoStatus copyWith(void Function(EchoStatus) updates) =>
-      super.copyWith((message) =>
-          updates(message as EchoStatus)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as EchoStatus))
+          as EchoStatus; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static EchoStatus create() => EchoStatus._();
@@ -230,7 +230,7 @@ class EchoStatus extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static EchoStatus getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<EchoStatus>(create);
-  static EchoStatus _defaultInstance;
+  static EchoStatus? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get code => $_getIZ(0);
@@ -289,14 +289,14 @@ class SimpleRequest extends $pb.GeneratedMessage {
 
   SimpleRequest._() : super();
   factory SimpleRequest({
-    PayloadType responseType,
-    $core.int responseSize,
-    Payload payload,
-    $core.bool fillUsername,
-    $core.bool fillOauthScope,
-    BoolValue responseCompressed,
-    EchoStatus responseStatus,
-    BoolValue expectCompressed,
+    PayloadType? responseType,
+    $core.int? responseSize,
+    Payload? payload,
+    $core.bool? fillUsername,
+    $core.bool? fillOauthScope,
+    BoolValue? responseCompressed,
+    EchoStatus? responseStatus,
+    BoolValue? expectCompressed,
   }) {
     final _result = create();
     if (responseType != null) {
@@ -339,8 +339,8 @@ class SimpleRequest extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   SimpleRequest copyWith(void Function(SimpleRequest) updates) =>
-      super.copyWith((message) =>
-          updates(message as SimpleRequest)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as SimpleRequest))
+          as SimpleRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SimpleRequest create() => SimpleRequest._();
@@ -350,7 +350,7 @@ class SimpleRequest extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static SimpleRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<SimpleRequest>(create);
-  static SimpleRequest _defaultInstance;
+  static SimpleRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   PayloadType get responseType => $_getN(0);
@@ -480,9 +480,9 @@ class SimpleResponse extends $pb.GeneratedMessage {
 
   SimpleResponse._() : super();
   factory SimpleResponse({
-    Payload payload,
-    $core.String username,
-    $core.String oauthScope,
+    Payload? payload,
+    $core.String? username,
+    $core.String? oauthScope,
   }) {
     final _result = create();
     if (payload != null) {
@@ -510,8 +510,8 @@ class SimpleResponse extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   SimpleResponse copyWith(void Function(SimpleResponse) updates) =>
-      super.copyWith((message) =>
-          updates(message as SimpleResponse)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as SimpleResponse))
+          as SimpleResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SimpleResponse create() => SimpleResponse._();
@@ -521,7 +521,7 @@ class SimpleResponse extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static SimpleResponse getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<SimpleResponse>(create);
-  static SimpleResponse _defaultInstance;
+  static SimpleResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   Payload get payload => $_getN(0);
@@ -585,8 +585,8 @@ class StreamingInputCallRequest extends $pb.GeneratedMessage {
 
   StreamingInputCallRequest._() : super();
   factory StreamingInputCallRequest({
-    Payload payload,
-    BoolValue expectCompressed,
+    Payload? payload,
+    BoolValue? expectCompressed,
   }) {
     final _result = create();
     if (payload != null) {
@@ -613,8 +613,8 @@ class StreamingInputCallRequest extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   StreamingInputCallRequest copyWith(
           void Function(StreamingInputCallRequest) updates) =>
-      super.copyWith((message) => updates(message
-          as StreamingInputCallRequest)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as StreamingInputCallRequest))
+          as StreamingInputCallRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static StreamingInputCallRequest create() => StreamingInputCallRequest._();
@@ -624,7 +624,7 @@ class StreamingInputCallRequest extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static StreamingInputCallRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<StreamingInputCallRequest>(create);
-  static StreamingInputCallRequest _defaultInstance;
+  static StreamingInputCallRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   Payload get payload => $_getN(0);
@@ -675,7 +675,7 @@ class StreamingInputCallResponse extends $pb.GeneratedMessage {
 
   StreamingInputCallResponse._() : super();
   factory StreamingInputCallResponse({
-    $core.int aggregatedPayloadSize,
+    $core.int? aggregatedPayloadSize,
   }) {
     final _result = create();
     if (aggregatedPayloadSize != null) {
@@ -699,8 +699,9 @@ class StreamingInputCallResponse extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   StreamingInputCallResponse copyWith(
           void Function(StreamingInputCallResponse) updates) =>
-      super.copyWith((message) => updates(message
-          as StreamingInputCallResponse)); // ignore: deprecated_member_use
+      super.copyWith(
+              (message) => updates(message as StreamingInputCallResponse))
+          as StreamingInputCallResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static StreamingInputCallResponse create() => StreamingInputCallResponse._();
@@ -710,7 +711,7 @@ class StreamingInputCallResponse extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static StreamingInputCallResponse getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<StreamingInputCallResponse>(create);
-  static StreamingInputCallResponse _defaultInstance;
+  static StreamingInputCallResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get aggregatedPayloadSize => $_getIZ(0);
@@ -754,9 +755,9 @@ class ResponseParameters extends $pb.GeneratedMessage {
 
   ResponseParameters._() : super();
   factory ResponseParameters({
-    $core.int size,
-    $core.int intervalUs,
-    BoolValue compressed,
+    $core.int? size,
+    $core.int? intervalUs,
+    BoolValue? compressed,
   }) {
     final _result = create();
     if (size != null) {
@@ -784,8 +785,8 @@ class ResponseParameters extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   ResponseParameters copyWith(void Function(ResponseParameters) updates) =>
-      super.copyWith((message) => updates(
-          message as ResponseParameters)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as ResponseParameters))
+          as ResponseParameters; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ResponseParameters create() => ResponseParameters._();
@@ -795,7 +796,7 @@ class ResponseParameters extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static ResponseParameters getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ResponseParameters>(create);
-  static ResponseParameters _defaultInstance;
+  static ResponseParameters? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get size => $_getIZ(0);
@@ -862,10 +863,10 @@ class StreamingOutputCallRequest extends $pb.GeneratedMessage {
 
   StreamingOutputCallRequest._() : super();
   factory StreamingOutputCallRequest({
-    PayloadType responseType,
-    $core.Iterable<ResponseParameters> responseParameters,
-    Payload payload,
-    EchoStatus responseStatus,
+    PayloadType? responseType,
+    $core.Iterable<ResponseParameters>? responseParameters,
+    Payload? payload,
+    EchoStatus? responseStatus,
   }) {
     final _result = create();
     if (responseType != null) {
@@ -898,8 +899,9 @@ class StreamingOutputCallRequest extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   StreamingOutputCallRequest copyWith(
           void Function(StreamingOutputCallRequest) updates) =>
-      super.copyWith((message) => updates(message
-          as StreamingOutputCallRequest)); // ignore: deprecated_member_use
+      super.copyWith(
+              (message) => updates(message as StreamingOutputCallRequest))
+          as StreamingOutputCallRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static StreamingOutputCallRequest create() => StreamingOutputCallRequest._();
@@ -909,7 +911,7 @@ class StreamingOutputCallRequest extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static StreamingOutputCallRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<StreamingOutputCallRequest>(create);
-  static StreamingOutputCallRequest _defaultInstance;
+  static StreamingOutputCallRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   PayloadType get responseType => $_getN(0);
@@ -975,7 +977,7 @@ class StreamingOutputCallResponse extends $pb.GeneratedMessage {
 
   StreamingOutputCallResponse._() : super();
   factory StreamingOutputCallResponse({
-    Payload payload,
+    Payload? payload,
   }) {
     final _result = create();
     if (payload != null) {
@@ -999,8 +1001,9 @@ class StreamingOutputCallResponse extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   StreamingOutputCallResponse copyWith(
           void Function(StreamingOutputCallResponse) updates) =>
-      super.copyWith((message) => updates(message
-          as StreamingOutputCallResponse)); // ignore: deprecated_member_use
+      super.copyWith(
+              (message) => updates(message as StreamingOutputCallResponse))
+          as StreamingOutputCallResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static StreamingOutputCallResponse create() =>
@@ -1011,7 +1014,7 @@ class StreamingOutputCallResponse extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static StreamingOutputCallResponse getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<StreamingOutputCallResponse>(create);
-  static StreamingOutputCallResponse _defaultInstance;
+  static StreamingOutputCallResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   Payload get payload => $_getN(0);
@@ -1048,7 +1051,7 @@ class ReconnectParams extends $pb.GeneratedMessage {
 
   ReconnectParams._() : super();
   factory ReconnectParams({
-    $core.int maxReconnectBackoffMs,
+    $core.int? maxReconnectBackoffMs,
   }) {
     final _result = create();
     if (maxReconnectBackoffMs != null) {
@@ -1070,8 +1073,8 @@ class ReconnectParams extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   ReconnectParams copyWith(void Function(ReconnectParams) updates) =>
-      super.copyWith((message) =>
-          updates(message as ReconnectParams)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as ReconnectParams))
+          as ReconnectParams; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReconnectParams create() => ReconnectParams._();
@@ -1081,7 +1084,7 @@ class ReconnectParams extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static ReconnectParams getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ReconnectParams>(create);
-  static ReconnectParams _defaultInstance;
+  static ReconnectParams? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get maxReconnectBackoffMs => $_getIZ(0);
@@ -1121,8 +1124,8 @@ class ReconnectInfo extends $pb.GeneratedMessage {
 
   ReconnectInfo._() : super();
   factory ReconnectInfo({
-    $core.bool passed,
-    $core.Iterable<$core.int> backoffMs,
+    $core.bool? passed,
+    $core.Iterable<$core.int>? backoffMs,
   }) {
     final _result = create();
     if (passed != null) {
@@ -1147,8 +1150,8 @@ class ReconnectInfo extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   ReconnectInfo copyWith(void Function(ReconnectInfo) updates) =>
-      super.copyWith((message) =>
-          updates(message as ReconnectInfo)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as ReconnectInfo))
+          as ReconnectInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReconnectInfo create() => ReconnectInfo._();
@@ -1158,7 +1161,7 @@ class ReconnectInfo extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static ReconnectInfo getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ReconnectInfo>(create);
-  static ReconnectInfo _defaultInstance;
+  static ReconnectInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get passed => $_getBF(0);

--- a/interop/lib/src/generated/messages.pbenum.dart
+++ b/interop/lib/src/generated/messages.pbenum.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: messages.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 // ignore_for_file: UNDEFINED_SHOWN_NAME
@@ -22,7 +22,7 @@ class PayloadType extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, PayloadType> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static PayloadType valueOf($core.int value) => _byValue[value];
+  static PayloadType? valueOf($core.int value) => _byValue[value];
 
   const PayloadType._($core.int v, $core.String n) : super(v, n);
 }

--- a/interop/lib/src/generated/test.pb.dart
+++ b/interop/lib/src/generated/test.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;

--- a/interop/lib/src/generated/test.pbgrpc.dart
+++ b/interop/lib/src/generated/test.pbgrpc.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:async' as $async;
@@ -59,29 +59,29 @@ class TestServiceClient extends $grpc.Client {
       ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
 
   TestServiceClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions options,
-      $core.Iterable<$grpc.ClientInterceptor> interceptors})
+      {$grpc.CallOptions? options,
+      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
   $grpc.ResponseFuture<$0.Empty> emptyCall($0.Empty request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$emptyCall, request, options: options);
   }
 
   $grpc.ResponseFuture<$1.SimpleResponse> unaryCall($1.SimpleRequest request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$unaryCall, request, options: options);
   }
 
   $grpc.ResponseFuture<$1.SimpleResponse> cacheableUnaryCall(
       $1.SimpleRequest request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$cacheableUnaryCall, request, options: options);
   }
 
   $grpc.ResponseStream<$1.StreamingOutputCallResponse> streamingOutputCall(
       $1.StreamingOutputCallRequest request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createStreamingCall(
         _$streamingOutputCall, $async.Stream.fromIterable([request]),
         options: options);
@@ -89,25 +89,25 @@ class TestServiceClient extends $grpc.Client {
 
   $grpc.ResponseFuture<$1.StreamingInputCallResponse> streamingInputCall(
       $async.Stream<$1.StreamingInputCallRequest> request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createStreamingCall(_$streamingInputCall, request, options: options)
         .single;
   }
 
   $grpc.ResponseStream<$1.StreamingOutputCallResponse> fullDuplexCall(
       $async.Stream<$1.StreamingOutputCallRequest> request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createStreamingCall(_$fullDuplexCall, request, options: options);
   }
 
   $grpc.ResponseStream<$1.StreamingOutputCallResponse> halfDuplexCall(
       $async.Stream<$1.StreamingOutputCallRequest> request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createStreamingCall(_$halfDuplexCall, request, options: options);
   }
 
   $grpc.ResponseFuture<$0.Empty> unimplementedCall($0.Empty request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$unimplementedCall, request, options: options);
   }
 }
@@ -235,12 +235,12 @@ class UnimplementedServiceClient extends $grpc.Client {
       ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
 
   UnimplementedServiceClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions options,
-      $core.Iterable<$grpc.ClientInterceptor> interceptors})
+      {$grpc.CallOptions? options,
+      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
   $grpc.ResponseFuture<$0.Empty> unimplementedCall($0.Empty request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$unimplementedCall, request, options: options);
   }
 }
@@ -278,17 +278,17 @@ class ReconnectServiceClient extends $grpc.Client {
       ($core.List<$core.int> value) => $1.ReconnectInfo.fromBuffer(value));
 
   ReconnectServiceClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions options,
-      $core.Iterable<$grpc.ClientInterceptor> interceptors})
+      {$grpc.CallOptions? options,
+      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
   $grpc.ResponseFuture<$0.Empty> start($1.ReconnectParams request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$start, request, options: options);
   }
 
   $grpc.ResponseFuture<$1.ReconnectInfo> stop($0.Empty request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$stop, request, options: options);
   }
 }

--- a/interop/pubspec.yaml
+++ b/interop/pubspec.yaml
@@ -3,10 +3,10 @@ description: Dart gRPC interoperability test suite.
 publish_to: none
 
 environment:
-  sdk: '>=2.8.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
-  args: ^1.5.2
+  args: ^2.0.0-nullsafety
   async: ^2.2.0
   collection: ^1.14.11
   grpc:
@@ -14,4 +14,7 @@ dependencies:
   protobuf: ^2.0.0-nullsafety
 
 dev_dependencies:
-  test: ^1.6.4
+  test: ^1.16.0-nullsafety.17
+
+dependency_overrides:
+  args: ^2.0.0-nullsafety

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,9 +13,9 @@ dependencies:
   async: ^2.2.0
   crypto: ^3.0.0-nullsafety
   fixnum: ^1.0.0-nullsafety
-  googleapis_auth: ^0.2.7
+  googleapis_auth: ^1.0.0-nullsafety
   meta: ^1.1.6
-  http: ^0.12.0
+  http: ^0.13.0-nullsafety
   http2: ^2.0.0-nullsafety
   protobuf: ^2.0.0-nullsafety.1
 
@@ -28,15 +28,5 @@ dev_dependencies:
   stream_transform: ^2.0.0-nullsafety
 
 dependency_overrides:
-  http:
-    git:
-      url: https://github.com/dart-lang/http.git
-      ref: 3845753a54624b070828cb3eff7a6c2a4e046cfb
-  googleapis_auth:
-    git:
-      url: https://github.com/dart-lang/googleapis_auth.git
-      ref: 30c084b7650fbd3e52525a127e0e65fc528e85a8
   shelf:
-    git:
-      url: https://github.com/dart-lang/shelf.git
-      ref: 2102572a6c27b1321823bb3e3723ddb5448e04ae
+    version: ^1.0.0-nullsafety


### PR DESCRIPTION
Also replace dependency_overrides with published versions

interop generated sources were regenerated using yet unmerged version of protoc_plugin (see https://github.com/dart-lang/protobuf/pull/466)

After this change I could run gRPC interop tests locally
