### PR TITLE
Make clientCertificate available in ServiceCall

### DIFF
--- a/lib/src/server/call.dart
+++ b/lib/src/server/call.dart
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:io';
+
 /// Server-side context for a gRPC call.
 ///
 /// Gives the method handler access to custom metadata from the client, and
@@ -38,6 +40,9 @@ abstract class ServiceCall {
 
   /// Returns [true] if the client has canceled this call.
   bool get isCanceled;
+
+  /// Returns the client certificate if it is requested and available
+  X509Certificate? get clientCertificate;
 
   /// Send response headers. This is done automatically before sending the first
   /// response message, but can be done manually before the first response is

--- a/lib/src/server/handler.dart
+++ b/lib/src/server/handler.dart
@@ -15,6 +15,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:http2/transport.dart';
 
@@ -58,13 +59,11 @@ class ServerHandler_ extends ServiceCall {
   bool _isCanceled = false;
   bool _isTimedOut = false;
   Timer? _timeoutTimer;
+  final X509Certificate? _clientCertificate;
 
-  ServerHandler_(
-    this._serviceLookup,
-    this._stream,
-    this._interceptors,
-    this._codecRegistry,
-  );
+  ServerHandler_(this._serviceLookup, this._stream, this._interceptors,
+      this._codecRegistry,
+      [this._clientCertificate]);
 
   @override
   DateTime? get deadline => _deadline;
@@ -83,6 +82,9 @@ class ServerHandler_ extends ServiceCall {
 
   @override
   Map<String, String>? get trailers => _customTrailers;
+
+  @override
+  X509Certificate? get clientCertificate => _clientCertificate;
 
   void handle() {
     _stream.onTerminated = (_) => cancel();
@@ -410,10 +412,10 @@ class ServerHandler_ extends ServiceCall {
 }
 
 class ServerHandler extends ServerHandler_ {
-  ServerHandler(
-    Service Function(String service) serviceLookup,
-    stream, [
-    List<Interceptor> interceptors = const <Interceptor>[],
-    CodecRegistry? codecRegistry,
-  ]) : super(serviceLookup, stream, interceptors, codecRegistry);
+  ServerHandler(Service Function(String service) serviceLookup, stream,
+      [List<Interceptor> interceptors = const <Interceptor>[],
+      CodecRegistry? codecRegistry,
+      X509Certificate? clientCertificate])
+      : super(serviceLookup, stream, interceptors, codecRegistry,
+            clientCertificate);
 }

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -162,6 +162,10 @@ class Server extends ConnectionServer {
   /// Starts the [Server] with the given options.
   /// [address] can be either a [String] or an [InternetAddress], in the latter
   /// case it can be a Unix Domain Socket address.
+  ///
+  /// If [port] is [null] then it defaults to `80` for non-secure and `443` for
+  /// secure variants.  Pass `0` for [port] to let OS select a port for the
+  /// server.
   Future<void> serve({
     dynamic address,
     int? port,

--- a/test/client_certificate_test.dart
+++ b/test/client_certificate_test.dart
@@ -1,4 +1,6 @@
-@TestOn('vm')
+// TODO(dartbug.com/26057) currently Mac OS X seems to have some issues with
+// client certificates so we disable the test.
+@TestOn('vm && !mac-os')
 import 'dart:async';
 import 'dart:io';
 

--- a/test/client_certificate_test.dart
+++ b/test/client_certificate_test.dart
@@ -87,6 +87,7 @@ Future<Server> _setUpServer([bool requireClientCertificate = false]) async {
       SecurityContextServerCredentials(serverContext);
   await server.serve(
       address: address,
+      port: 0,
       security: serverCredentials,
       requireClientCertificate: requireClientCertificate);
   return server;

--- a/test/client_certificate_test.dart
+++ b/test/client_certificate_test.dart
@@ -24,7 +24,6 @@ class EchoService extends EchoServiceBase {
 
 const String address = 'localhost';
 Future<void> main() async {
-  setUp(() {});
   test('Client certificate required', () async {
     // Server
     final server = await _setUpServer(true);

--- a/test/client_certificate_test.dart
+++ b/test/client_certificate_test.dart
@@ -1,0 +1,131 @@
+@TestOn('vm')
+import 'dart:async';
+import 'dart:io';
+
+import 'package:grpc/grpc.dart';
+import 'package:test/test.dart';
+
+import 'src/generated/echo.pbgrpc.dart';
+
+class EchoService extends EchoServiceBase {
+  @override
+  Future<EchoResponse> echo(ServiceCall call, EchoRequest request) async {
+    final subject = call.clientCertificate?.subject;
+    return (EchoResponse()..message = subject ?? 'NO CERT');
+  }
+
+  @override
+  Stream<ServerStreamingEchoResponse> serverStreamingEcho(
+      ServiceCall call, ServerStreamingEchoRequest request) {
+    // TODO: implement serverStreamingEcho
+    throw UnimplementedError();
+  }
+}
+
+const String address = 'localhost';
+const int port = 19360;
+Future<void> main() async {
+  test('Client certificate required', () async {
+    //Server
+    final server = Server(
+      [EchoService()],
+    );
+    final serverContext =
+        SecurityContextChannelCredentials.baseSecurityContext();
+
+    serverContext.useCertificateChain('test/data/localhost.crt');
+    serverContext.usePrivateKey('test/data/localhost.key');
+    serverContext.setTrustedCertificates('test/data/localhost.crt');
+    final ServerCredentials serverCredentials =
+        SecurityContextServerCredentials(serverContext);
+
+    await server.serve(
+        address: address,
+        port: port,
+        security: serverCredentials,
+        requireClientCertificate: true);
+
+    //Client
+    final channelContext =
+        SecurityContextChannelCredentials.baseSecurityContext();
+    channelContext.useCertificateChain(
+      'test/data/localhost.crt',
+    );
+    channelContext.usePrivateKey('test/data/localhost.key');
+    final channelCredentials = SecurityContextChannelCredentials(channelContext,
+        onBadCertificate: (cert, s) {
+      return true;
+    });
+    final channel = ClientChannel(address,
+        port: port, options: ChannelOptions(credentials: channelCredentials));
+    final client = EchoServiceClient(channel);
+    expect((await client.echo(EchoRequest())).message, '/CN=localhost');
+    await channel.shutdown();
+    await server.shutdown();
+  });
+
+  test('Client certificate not required', () async {
+    //Server
+    final server = Server(
+      [EchoService()],
+    );
+    final serverContext =
+        SecurityContextChannelCredentials.baseSecurityContext();
+
+    serverContext.useCertificateChain('test/data/localhost.crt');
+    serverContext.usePrivateKey('test/data/localhost.key');
+    serverContext.setTrustedCertificates('test/data/localhost.crt');
+    final ServerCredentials serverCredentials =
+        SecurityContextServerCredentials(serverContext);
+    await server.serve(
+      address: address,
+      port: port,
+      security: serverCredentials,
+    );
+    // Client
+    final channelContext =
+        SecurityContextChannelCredentials.baseSecurityContext();
+    channelContext.useCertificateChain(
+      'test/data/localhost.crt',
+    );
+    channelContext.usePrivateKey('test/data/localhost.key');
+    final channelCredentials = SecurityContextChannelCredentials(channelContext,
+        onBadCertificate: (cert, s) {
+      return true;
+    });
+    final channel = ClientChannel(address,
+        port: port, options: ChannelOptions(credentials: channelCredentials));
+    final client = EchoServiceClient(channel);
+    expect((await client.echo(EchoRequest())).message, 'NO CERT');
+    await channel.shutdown();
+    await server.shutdown();
+  });
+}
+
+class SecurityContextChannelCredentials extends ChannelCredentials {
+  final SecurityContext _securityContext;
+
+  SecurityContextChannelCredentials(SecurityContext securityContext,
+      {String? authority, BadCertificateHandler? onBadCertificate})
+      : _securityContext = securityContext,
+        super.secure(authority: authority, onBadCertificate: onBadCertificate);
+  @override
+  SecurityContext get securityContext => _securityContext;
+
+  static SecurityContext baseSecurityContext() {
+    return createSecurityContext(false);
+  }
+}
+
+class SecurityContextServerCredentials extends ServerTlsCredentials {
+  final SecurityContext _securityContext;
+
+  SecurityContextServerCredentials(SecurityContext securityContext)
+      : _securityContext = securityContext,
+        super();
+  @override
+  SecurityContext get securityContext => _securityContext;
+  static SecurityContext baseSecurityContext() {
+    return createSecurityContext(true);
+  }
+}


### PR DESCRIPTION
The current server implementation does not allow to access the certificate of the client in an incoming call. The main reason for accessing the client certificate in a call is to authenticate the underlying user. To this purpose we extended the ServiceCall with a new getter `X509Certificate? get clientCertificate;`. The client certificate is then obtained from the SecureSocket and passed through. To request/require the client certificate, the `Server.serve()` method has two new optional parameters `requestClientCertificate` and `requireClientCertificate`, which are used in `SecureServerSocket.bind()` to make the certificate request.