### PR TITLE
GrpcOrGrpcWeb: remove checking if ports are different (#482)

### DIFF
--- a/lib/grpc_or_grpcweb.dart
+++ b/lib/grpc_or_grpcweb.dart
@@ -17,9 +17,13 @@
 /// on all platfroms except web, on which it uses [GrpcWebClientChannel].
 ///
 /// Note that gRPC and gRPC-web are 2 different protocols and server must be
-/// able to speak both of them (usually on separate ports) for this to work.
-/// Therefore applications using this class must provide both ports and the
-/// channel will use the one for the actual protocol being used.
+/// able to speak both of them for this to work.
+/// As several existing implementations (such as in-process gRPC-web to gRPC
+/// proxies or Envoy gRPC-web to gRPC proxy) expose gRPC and gRPC-web on
+/// separate ports, the constructor requires 2 ports to be provided and
+/// the channel will use the one for the actual protocol being used.
+/// If the server supports both protocols on the same port (such as AspNetCore
+/// implementation), then the same port value should be provided on both params.
 
 export 'src/client/grpc_or_grpcweb_channel_grpc.dart'
     if (dart.library.html) 'src/client/grpc_or_grpcweb_channel_web.dart';

--- a/lib/grpc_or_grpcweb.dart
+++ b/lib/grpc_or_grpcweb.dart
@@ -17,9 +17,9 @@
 /// on all platfroms except web, on which it uses [GrpcWebClientChannel].
 ///
 /// Note that gRPC and gRPC-web are 2 different protocols and server must be
-/// able to speak both of them (on separate ports) for this to work. Therefore
-/// applications using this class must provide both ports and the channel will
-/// use the one for the actual protocol being used.
+/// able to speak both of them (usually on separate ports) for this to work.
+/// Therefore applications using this class must provide both ports and the
+/// channel will use the one for the actual protocol being used.
 
 export 'src/client/grpc_or_grpcweb_channel_grpc.dart'
     if (dart.library.html) 'src/client/grpc_or_grpcweb_channel_web.dart';

--- a/lib/src/client/grpc_or_grpcweb_channel_grpc.dart
+++ b/lib/src/client/grpc_or_grpcweb_channel_grpc.dart
@@ -31,11 +31,7 @@ class GrpcOrGrpcWebClientChannel extends ClientChannel {
                 ? ChannelCredentials.secure()
                 : ChannelCredentials.insecure(),
           ),
-        ) {
-    if (grpcWebPort == grpcPort) {
-      throw ArgumentError('grpcPort and grpcWebPort cannot be the same');
-    }
-  }
+        );
 
   GrpcOrGrpcWebClientChannel.grpc(
     Object host, {

--- a/lib/src/client/grpc_or_grpcweb_channel_web.dart
+++ b/lib/src/client/grpc_or_grpcweb_channel_web.dart
@@ -23,11 +23,7 @@ class GrpcOrGrpcWebClientChannel extends GrpcWebClientChannel {
     required int grpcWebPort,
     required bool secure,
   }) : super.xhr(Uri(
-            host: host, port: grpcWebPort, scheme: secure ? 'https' : 'http')) {
-    if (grpcWebPort == grpcPort) {
-      throw ArgumentError('grpcPort and grpcWebPort cannot be the same');
-    }
-  }
+            host: host, port: grpcWebPort, scheme: secure ? 'https' : 'http'));
 
   GrpcOrGrpcWebClientChannel.grpc(
     Object host, {

--- a/test/client_tests/grpc_or_grpcweb_channel_grpc_test.dart
+++ b/test/client_tests/grpc_or_grpcweb_channel_grpc_test.dart
@@ -36,17 +36,6 @@ void main() {
     expect(channel.options.credentials.isSecure, isFalse);
   });
 
-  test('Constructor throws throwsArgumentError if ports are the same', () {
-    expect(
-        () => GrpcOrGrpcWebClientChannel(
-              host: host,
-              grpcPort: grpcPort,
-              grpcWebPort: grpcPort,
-              secure: false,
-            ),
-        throwsArgumentError);
-  });
-
   test('Constructor grpc on non-web passes params correctly', () {
     final options = ChannelOptions(credentials: ChannelCredentials.insecure());
     final channel = GrpcOrGrpcWebClientChannel.grpc(

--- a/test/client_tests/grpc_or_grpcweb_channel_web_test.dart
+++ b/test/client_tests/grpc_or_grpcweb_channel_web_test.dart
@@ -36,17 +36,6 @@ void main() {
         equals(Uri(host: host, port: grpcWebPort, scheme: 'https')));
   });
 
-  test('Constructor throws throwsArgumentError if ports are the same', () {
-    expect(
-        () => GrpcOrGrpcWebClientChannel(
-              host: host,
-              grpcPort: grpcPort,
-              grpcWebPort: grpcPort,
-              secure: false,
-            ),
-        throwsArgumentError);
-  });
-
   test('Constructor grpc on web throws UnsupportedError', () {
     expect(() => GrpcOrGrpcWebClientChannel.grpc(host, port: grpcPort),
         throwsUnsupportedError);


### PR DESCRIPTION
Using the same port is a standard for AspNetCore gRPC server.

@mraleph
@gustav3d