### PR TITLE
GrpcOrGrpcWeb: provide more flexible constructors (#484)

### DIFF
--- a/lib/grpc_or_grpcweb.dart
+++ b/lib/grpc_or_grpcweb.dart
@@ -16,10 +16,10 @@
 import 'src/client/grpc_or_grpcweb_channel_grpc.dart'
     if (dart.library.html) 'src/client/grpc_or_grpcweb_channel_web.dart';
 import 'src/client/http2_channel.dart';
+import 'src/client/options.dart';
 
-/// Exports [GrpcOrGrpcWebClientChannel] that underneath uses gRPC
-/// [ClientChannel] on all platforms except web, on which it uses
-/// [GrpcWebClientChannel].
+/// A client channel that underneath uses gRPC [ClientChannel] on all platforms
+/// except web, on which it uses [GrpcWebClientChannel].
 ///
 /// Note that gRPC and gRPC-web are 2 different protocols and server must be
 /// able to speak both of them for this to work.
@@ -28,42 +28,56 @@ import 'src/client/http2_channel.dart';
 /// example), on separate ports of the same host (common setup of in-process
 /// gRPC-web to gRPC proxies or colocated Envoy gRPC-web to gRPC proxy), or as
 /// a completely separate endpoints (for example if Envoy and gRPC server are
-/// exposed as different kubernetes services). A corresponding constructor or a
-/// static extension in [GrpcOrGrpcWebClientChannelConstructors] is provided for
-/// each case.
-export 'src/client/grpc_or_grpcweb_channel_grpc.dart'
-    if (dart.library.html) 'src/client/grpc_or_grpcweb_channel_web.dart';
+/// exposed as different kubernetes services). A corresponding constructor is
+/// provided for each case.
+class GrpcOrGrpcWebClientChannel extends GrpcOrGrpcWebClientChannelInternal {
+  GrpcOrGrpcWebClientChannel.toSeparateEndpoints({
+    required String grpcHost,
+    required int grpcPort,
+    required bool grpcTransportSecure,
+    required String grpcWebHost,
+    required int grpcWebPort,
+    required bool grpcWebTransportSecure,
+  }) : super(
+          grpcHost: grpcHost,
+          grpcPort: grpcPort,
+          grpcTransportSecure: grpcTransportSecure,
+          grpcWebHost: grpcWebHost,
+          grpcWebPort: grpcWebPort,
+          grpcWebTransportSecure: grpcWebTransportSecure,
+        );
 
-extension GrpcOrGrpcWebClientChannelConstructors on GrpcOrGrpcWebClientChannel {
-  static GrpcOrGrpcWebClientChannel toSeparatePorts({
+  GrpcOrGrpcWebClientChannel.toSeparatePorts({
     required String host,
     required int grpcPort,
     required bool grpcTransportSecure,
     required int grpcWebPort,
     required bool grpcWebTransportSecure,
-  }) {
-    return GrpcOrGrpcWebClientChannel.toSeparateEndpoints(
-      grpcHost: host,
-      grpcPort: grpcPort,
-      grpcTransportSecure: grpcTransportSecure,
-      grpcWebHost: host,
-      grpcWebPort: grpcWebPort,
-      grpcWebTransportSecure: grpcWebTransportSecure,
-    );
-  }
+  }) : super(
+          grpcHost: host,
+          grpcPort: grpcPort,
+          grpcTransportSecure: grpcTransportSecure,
+          grpcWebHost: host,
+          grpcWebPort: grpcWebPort,
+          grpcWebTransportSecure: grpcWebTransportSecure,
+        );
 
-  static GrpcOrGrpcWebClientChannel toSingleEndpoint({
+  GrpcOrGrpcWebClientChannel.toSingleEndpoint({
     required String host,
     required int port,
     required bool transportSecure,
-  }) {
-    return GrpcOrGrpcWebClientChannel.toSeparateEndpoints(
-      grpcHost: host,
-      grpcPort: port,
-      grpcTransportSecure: transportSecure,
-      grpcWebHost: host,
-      grpcWebPort: port,
-      grpcWebTransportSecure: transportSecure,
-    );
-  }
+  }) : super(
+          grpcHost: host,
+          grpcPort: port,
+          grpcTransportSecure: transportSecure,
+          grpcWebHost: host,
+          grpcWebPort: port,
+          grpcWebTransportSecure: transportSecure,
+        );
+
+  GrpcOrGrpcWebClientChannel.grpc(
+    Object host, {
+    int port = 443,
+    ChannelOptions options = const ChannelOptions(),
+  }) : super.grpc(host, port: port, options: options);
 }

--- a/lib/grpc_or_grpcweb.dart
+++ b/lib/grpc_or_grpcweb.dart
@@ -13,17 +13,57 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Exports [GrpcOrWebClientChannel] that underneath uses gRPC [ClientChannel]
-/// on all platfroms except web, on which it uses [GrpcWebClientChannel].
+import 'src/client/grpc_or_grpcweb_channel_grpc.dart'
+    if (dart.library.html) 'src/client/grpc_or_grpcweb_channel_web.dart';
+import 'src/client/http2_channel.dart';
+
+/// Exports [GrpcOrGrpcWebClientChannel] that underneath uses gRPC
+/// [ClientChannel] on all platforms except web, on which it uses
+/// [GrpcWebClientChannel].
 ///
 /// Note that gRPC and gRPC-web are 2 different protocols and server must be
 /// able to speak both of them for this to work.
-/// As several existing implementations (such as in-process gRPC-web to gRPC
-/// proxies or Envoy gRPC-web to gRPC proxy) expose gRPC and gRPC-web on
-/// separate ports, the constructor requires 2 ports to be provided and
-/// the channel will use the one for the actual protocol being used.
-/// If the server supports both protocols on the same port (such as AspNetCore
-/// implementation), then the same port value should be provided on both params.
-
+/// Depending on its exact setup, the server may expose gRPC and gRPC-web on the
+/// same port (this is the standard setup of AspNetCore implementation for
+/// example), on separate ports of the same host (common setup of in-process
+/// gRPC-web to gRPC proxies or colocated Envoy gRPC-web to gRPC proxy), or as
+/// a completely separate endpoints (for example if Envoy and gRPC server are
+/// exposed as different kubernetes services). A corresponding constructor or a
+/// static extension in [GrpcOrGrpcWebClientChannelConstructors] is provided for
+/// each case.
 export 'src/client/grpc_or_grpcweb_channel_grpc.dart'
     if (dart.library.html) 'src/client/grpc_or_grpcweb_channel_web.dart';
+
+extension GrpcOrGrpcWebClientChannelConstructors on GrpcOrGrpcWebClientChannel {
+  static GrpcOrGrpcWebClientChannel toSeparatePorts({
+    required String host,
+    required int grpcPort,
+    required bool grpcTransportSecure,
+    required int grpcWebPort,
+    required bool grpcWebTransportSecure,
+  }) {
+    return GrpcOrGrpcWebClientChannel.toSeparateEndpoints(
+      grpcHost: host,
+      grpcPort: grpcPort,
+      grpcTransportSecure: grpcTransportSecure,
+      grpcWebHost: host,
+      grpcWebPort: grpcWebPort,
+      grpcWebTransportSecure: grpcWebTransportSecure,
+    );
+  }
+
+  static GrpcOrGrpcWebClientChannel toSingleEndpoint({
+    required String host,
+    required int port,
+    required bool transportSecure,
+  }) {
+    return GrpcOrGrpcWebClientChannel.toSeparateEndpoints(
+      grpcHost: host,
+      grpcPort: port,
+      grpcTransportSecure: transportSecure,
+      grpcWebHost: host,
+      grpcWebPort: port,
+      grpcWebTransportSecure: transportSecure,
+    );
+  }
+}

--- a/lib/src/client/grpc_or_grpcweb_channel_grpc.dart
+++ b/lib/src/client/grpc_or_grpcweb_channel_grpc.dart
@@ -17,8 +17,8 @@ import 'http2_channel.dart';
 import 'options.dart';
 import 'transport/http2_credentials.dart';
 
-class GrpcOrGrpcWebClientChannel extends ClientChannel {
-  GrpcOrGrpcWebClientChannel.toSeparateEndpoints({
+class GrpcOrGrpcWebClientChannelInternal extends ClientChannel {
+  GrpcOrGrpcWebClientChannelInternal({
     required String grpcHost,
     required int grpcPort,
     required bool grpcTransportSecure,
@@ -35,9 +35,9 @@ class GrpcOrGrpcWebClientChannel extends ClientChannel {
           ),
         );
 
-  GrpcOrGrpcWebClientChannel.grpc(
+  GrpcOrGrpcWebClientChannelInternal.grpc(
     Object host, {
-    int port = 443,
-    ChannelOptions options = const ChannelOptions(),
+    required int port,
+    required ChannelOptions options,
   }) : super(host, port: port, options: options);
 }

--- a/lib/src/client/grpc_or_grpcweb_channel_grpc.dart
+++ b/lib/src/client/grpc_or_grpcweb_channel_grpc.dart
@@ -18,16 +18,18 @@ import 'options.dart';
 import 'transport/http2_credentials.dart';
 
 class GrpcOrGrpcWebClientChannel extends ClientChannel {
-  GrpcOrGrpcWebClientChannel({
-    required String host,
+  GrpcOrGrpcWebClientChannel.toSeparateEndpoints({
+    required String grpcHost,
     required int grpcPort,
+    required bool grpcTransportSecure,
+    required String grpcWebHost,
     required int grpcWebPort,
-    required bool secure,
+    required bool grpcWebTransportSecure,
   }) : super(
-          host,
+          grpcHost,
           port: grpcPort,
           options: ChannelOptions(
-            credentials: secure
+            credentials: grpcTransportSecure
                 ? ChannelCredentials.secure()
                 : ChannelCredentials.insecure(),
           ),

--- a/lib/src/client/grpc_or_grpcweb_channel_web.dart
+++ b/lib/src/client/grpc_or_grpcweb_channel_web.dart
@@ -32,8 +32,8 @@ class GrpcOrGrpcWebClientChannelInternal extends GrpcWebClientChannel {
 
   GrpcOrGrpcWebClientChannelInternal.grpc(
     Object host, {
-    int port = 443,
-    ChannelOptions options = const ChannelOptions(),
+    required int port,
+    required ChannelOptions options,
   }) : super.xhr(
           Uri(
               host: host.toString(),

--- a/lib/src/client/grpc_or_grpcweb_channel_web.dart
+++ b/lib/src/client/grpc_or_grpcweb_channel_web.dart
@@ -16,8 +16,8 @@
 import 'options.dart';
 import 'web_channel.dart';
 
-class GrpcOrGrpcWebClientChannel extends GrpcWebClientChannel {
-  GrpcOrGrpcWebClientChannel.toSeparateEndpoints({
+class GrpcOrGrpcWebClientChannelInternal extends GrpcWebClientChannel {
+  GrpcOrGrpcWebClientChannelInternal({
     required String grpcHost,
     required int grpcPort,
     required bool grpcTransportSecure,
@@ -30,7 +30,7 @@ class GrpcOrGrpcWebClientChannel extends GrpcWebClientChannel {
           scheme: grpcWebTransportSecure ? 'https' : 'http',
         ));
 
-  GrpcOrGrpcWebClientChannel.grpc(
+  GrpcOrGrpcWebClientChannelInternal.grpc(
     Object host, {
     int port = 443,
     ChannelOptions options = const ChannelOptions(),

--- a/lib/src/client/grpc_or_grpcweb_channel_web.dart
+++ b/lib/src/client/grpc_or_grpcweb_channel_web.dart
@@ -17,13 +17,18 @@ import 'options.dart';
 import 'web_channel.dart';
 
 class GrpcOrGrpcWebClientChannel extends GrpcWebClientChannel {
-  GrpcOrGrpcWebClientChannel({
-    required String host,
+  GrpcOrGrpcWebClientChannel.toSeparateEndpoints({
+    required String grpcHost,
     required int grpcPort,
+    required bool grpcTransportSecure,
+    required String grpcWebHost,
     required int grpcWebPort,
-    required bool secure,
+    required bool grpcWebTransportSecure,
   }) : super.xhr(Uri(
-            host: host, port: grpcWebPort, scheme: secure ? 'https' : 'http'));
+          host: grpcWebHost,
+          port: grpcWebPort,
+          scheme: grpcWebTransportSecure ? 'https' : 'http',
+        ));
 
   GrpcOrGrpcWebClientChannel.grpc(
     Object host, {

--- a/test/client_tests/grpc_or_grpcweb_channel_grpc_test.dart
+++ b/test/client_tests/grpc_or_grpcweb_channel_grpc_test.dart
@@ -23,7 +23,7 @@ const port = 8080;
 
 void main() {
   test('Channel on non-web uses gRPC ClientChannel with correct params', () {
-    final channel = GrpcOrGrpcWebClientChannelConstructors.toSingleEndpoint(
+    final channel = GrpcOrGrpcWebClientChannel.toSingleEndpoint(
       host: host,
       port: port,
       transportSecure: false,

--- a/test/client_tests/grpc_or_grpcweb_channel_grpc_test.dart
+++ b/test/client_tests/grpc_or_grpcweb_channel_grpc_test.dart
@@ -19,20 +19,18 @@ import 'package:grpc/grpc_or_grpcweb.dart';
 import 'package:test/test.dart';
 
 const host = 'example.com';
-const grpcPort = 9090;
-const grpcWebPort = 8080;
+const port = 8080;
 
 void main() {
   test('Channel on non-web uses gRPC ClientChannel with correct params', () {
-    final channel = GrpcOrGrpcWebClientChannel(
+    final channel = GrpcOrGrpcWebClientChannelConstructors.toSingleEndpoint(
       host: host,
-      grpcPort: grpcPort,
-      grpcWebPort: grpcWebPort,
-      secure: false,
+      port: port,
+      transportSecure: false,
     );
     expect(channel is ClientChannel, isTrue);
     expect(channel.host, equals(host));
-    expect(channel.port, equals(grpcPort));
+    expect(channel.port, equals(port));
     expect(channel.options.credentials.isSecure, isFalse);
   });
 
@@ -40,11 +38,11 @@ void main() {
     final options = ChannelOptions(credentials: ChannelCredentials.insecure());
     final channel = GrpcOrGrpcWebClientChannel.grpc(
       host,
-      port: grpcPort,
+      port: port,
       options: options,
     );
     expect(channel.host, equals(host));
-    expect(channel.port, equals(grpcPort));
+    expect(channel.port, equals(port));
     expect(channel.options, same(options));
   });
 }

--- a/test/client_tests/grpc_or_grpcweb_channel_web_test.dart
+++ b/test/client_tests/grpc_or_grpcweb_channel_web_test.dart
@@ -19,25 +19,23 @@ import 'package:grpc/grpc_web.dart';
 import 'package:test/test.dart';
 
 const host = 'example.com';
-const grpcPort = 9090;
-const grpcWebPort = 8080;
+const port = 8080;
 
 void main() {
   test('Channel on web uses GrpcWebClientChannel with correct URI', () {
-    final channel = GrpcOrGrpcWebClientChannel(
+    final channel = GrpcOrGrpcWebClientChannelConstructors.toSingleEndpoint(
       host: host,
-      grpcPort: grpcPort,
-      grpcWebPort: grpcWebPort,
-      secure: true,
+      port: port,
+      transportSecure: true,
     );
     expect(channel is GrpcWebClientChannel, isTrue);
     final webChannel = channel as GrpcWebClientChannel;
     expect(webChannel.uri,
-        equals(Uri(host: host, port: grpcWebPort, scheme: 'https')));
+        equals(Uri(host: host, port: port, scheme: 'https')));
   });
 
   test('Constructor grpc on web throws UnsupportedError', () {
-    expect(() => GrpcOrGrpcWebClientChannel.grpc(host, port: grpcPort),
+    expect(() => GrpcOrGrpcWebClientChannel.grpc(host, port: port),
         throwsUnsupportedError);
   });
 }

--- a/test/client_tests/grpc_or_grpcweb_channel_web_test.dart
+++ b/test/client_tests/grpc_or_grpcweb_channel_web_test.dart
@@ -23,7 +23,7 @@ const port = 8080;
 
 void main() {
   test('Channel on web uses GrpcWebClientChannel with correct URI', () {
-    final channel = GrpcOrGrpcWebClientChannelConstructors.toSingleEndpoint(
+    final channel = GrpcOrGrpcWebClientChannel.toSingleEndpoint(
       host: host,
       port: port,
       transportSecure: true,

--- a/test/client_tests/grpc_or_grpcweb_channel_web_test.dart
+++ b/test/client_tests/grpc_or_grpcweb_channel_web_test.dart
@@ -30,8 +30,8 @@ void main() {
     );
     expect(channel is GrpcWebClientChannel, isTrue);
     final webChannel = channel as GrpcWebClientChannel;
-    expect(webChannel.uri,
-        equals(Uri(host: host, port: port, scheme: 'https')));
+    expect(
+        webChannel.uri, equals(Uri(host: host, port: port, scheme: 'https')));
   });
 
   test('Constructor grpc on web throws UnsupportedError', () {


### PR DESCRIPTION
@mraleph 

btw: it would be soooo awesome if https://github.com/dart-lang/language/issues/723 was implemented, so that it would be transparent for library users if they are using a 'native' constructor or an extension  ;-)
(for example [here](https://github.com/morgwai/grpc-dart/blob/grpcOrWebConstructors/test/client_tests/grpc_or_grpcweb_channel_grpc_test.dart#L26) I could write
```dart
GrpcOrGrpcWebClientChannel.toSingleEndpoint(...);
```
instead of 
```dart
GrpcOrGrpcWebClientChannelConstructors.toSingleEndpoint(...);
```
)