### PR TITLE
Fix a typo on the inner invoker parameters

### DIFF
--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -60,7 +60,7 @@ regenerate these stubs using  protobuf compiler plugin version 19.2.0 or newer.
   ResponseStream<R> $createStreamingCall<Q, R>(
       ClientMethod<Q, R> method, Stream<Q> requests,
       {CallOptions? options}) {
-    var invoker = (method, request, options) =>
+    var invoker = (method, requests, options) =>
         ResponseStream<R>(_channel.createCall<Q, R>(method, requests, options));
 
     for (final interceptor in _interceptors.reversed) {


### PR DESCRIPTION
The operations on the request stream of the ClientInerceptor items are ignored when calls the last invoker which creates the ResponseStream.