### PR TITLE
Add Ctrl+C Handler

### DIFF
--- a/example/helloworld/bin/server.dart
+++ b/example/helloworld/bin/server.dart
@@ -33,4 +33,11 @@ Future<void> main(List<String> args) async {
   );
   await server.serve(port: 50051);
   print('Server listening on port ${server.port}...');
+  ProcessSignal.SIGINT.watch().listen((signal) {
+    if (signal == ProcessSignal.SIGINT){
+      print("Shutting down");
+      server.shutdown();
+      exit(0); 
+    }
+  });
 }

--- a/example/helloworld/bin/unix_server.dart
+++ b/example/helloworld/bin/unix_server.dart
@@ -33,4 +33,11 @@ Future<void> main(List<String> args) async {
   final server = Server([GreeterService()]);
   await server.serve(address: udsAddress);
   print('Start UNIX Server @localhost...');
+  ProcessSignal.SIGINT.watch().listen((signal) {
+    if (signal == ProcessSignal.SIGINT){
+      print("Shutting down");
+      server.shutdown();
+      exit(0); 
+    }
+  });
 }


### PR DESCRIPTION
If using Unix domain sockets, the old socket needs to be cleaned up properly, or restarting the server will cause it to refuse to bind. Added a handler for SIGINT to call shutdown explicitly and then exit.

This is the first time I've written in Dart - am completely open to changes.