### PR TITLE
Send trailers included on GrpcError object

### DIFF
--- a/lib/src/server/handler.dart
+++ b/lib/src/server/handler.dart
@@ -328,7 +328,8 @@ class ServerHandler_ extends ServiceCall {
   }
 
   @override
-  void sendTrailers({int? status = 0, String? message}) {
+  void sendTrailers(
+      {int? status = 0, String? message, Map<String, String>? errorTrailers}) {
     _timeoutTimer?.cancel();
 
     final outgoingTrailersMap = <String, String>{};
@@ -353,6 +354,9 @@ class ServerHandler_ extends ServiceCall {
     if (message != null) {
       outgoingTrailersMap['grpc-message'] =
           Uri.encodeFull(message).replaceAll('%20', ' ');
+    }
+    if (errorTrailers != null) {
+      outgoingTrailersMap.addAll(errorTrailers);
     }
 
     final outgoingTrailers = <Header>[];
@@ -407,7 +411,11 @@ class ServerHandler_ extends ServiceCall {
   }
 
   void _sendError(GrpcError error) {
-    sendTrailers(status: error.code, message: error.message);
+    sendTrailers(
+      status: error.code,
+      message: error.message,
+      errorTrailers: error.trailers,
+    );
   }
 
   void cancel() {


### PR DESCRIPTION
A previous PR #493 solved the problem of receiving trailers within the GrpcError object from the client. It works well with servers built in other languages that send those trailers. But the piece that was still missing is the inclusion of those trailers when this library is being used on the server.

So, if the following method on the server throws an error containing trailers:

```dart
    throw GrpcError.custom(
      StatusCode.internal,
      'This error should contain trailers',
      null,
      null,
      {
        'key1': 'value1',
        'key2': 'value2',
      },
    );

```
The client should be receiving the trailers, just like it would from a server developed on any other gRPC server language. The following client-side code should print ```It has the trailers: {key1: value1, key2: value2}```.
```dart
Future<void> main(List<String> args) async {
  final channel = ClientChannel(
    'localhost',
    port: 50051,
    options: ChannelOptions(
      credentials: ChannelCredentials.insecure(),
      codecRegistry:
          CodecRegistry(codecs: const [GzipCodec(), IdentityCodec()]),
    ),
  );
  final stub = GreeterClient(channel);

  final name = args.isNotEmpty ? args[0] : 'world';

  try {
    final response = await stub.sayHello(
      HelloRequest()..name = name,
      options: CallOptions(compression: const GzipCodec()),
    );
    print('Greeter client received: ${response.message}');
  } on GrpcError catch (e) {
    print('It has the trailers: ${e.trailers}');
  }
  await channel.shutdown();
}
```

I added a new test on [round_trip_test.dart] called ```trailers on server GrpcError```, which is green along with all other tests.