### PR TITLE
feat: allow to make future chain request with ResponseFuture and ResponseStream

### DIFF
--- a/lib/src/client/common.dart
+++ b/lib/src/client/common.dart
@@ -63,6 +63,28 @@ class ResponseFuture<R> extends DelegatingFuture<R>
       : super(_call.response
             .fold<R?>(null, _ensureOnlyOneResponse)
             .then(_ensureOneResponse));
+
+  ResponseFuture._next(this._call, Future<R> future) : super(future);
+
+  ResponseFuture<R> responseThen(FutureOr<R> Function(R p1) onValue,
+      {Function? onError}) {
+    return ResponseFuture._next(_call, then(onValue, onError: onError));
+  }
+
+  ResponseFuture<R> responseCatchError(Function onError,
+      {bool Function(Object error)? test}) {
+    return ResponseFuture._next(_call, catchError(onError, test: test));
+  }
+
+  ResponseFuture<R> responseWhenComplete(FutureOr Function() action) {
+    return ResponseFuture._next(_call, whenComplete(action));
+  }
+
+  ResponseFuture<R> responseTimeout(Duration timeLimit,
+      {FutureOr<R> Function()? onTimeout}) {
+    return ResponseFuture._next(
+        _call, timeout(timeLimit, onTimeout: onTimeout));
+  }
 }
 
 /// A gRPC response producing a stream of values.

--- a/lib/src/client/common.dart
+++ b/lib/src/client/common.dart
@@ -97,6 +97,15 @@ class ResponseStream<R> extends DelegatingStream<R>
 
   @override
   ResponseFuture<R> get single => ResponseFuture(_call);
+
+  ResponseStream._next(this._call, Stream<R> future) : super(future);
+
+  ResponseStream<S> responseTransform<S>(StreamTransformer<R, S> transformer) {
+    return ResponseStream<S>._next(
+      _call as dynamic,
+      transform(transformer),
+    );
+  }
 }
 
 abstract class _ResponseMixin<Q, R> implements Response {

--- a/test/client_tests/response_future_test.dart
+++ b/test/client_tests/response_future_test.dart
@@ -43,12 +43,13 @@ void main() {
 
   test('Support ResponseFuture after ResponseFuture', () async {
     final response1 = 1;
-    final response2 = 1;
+    final response2 = 2;
 
     final responseFuture1 = ResponseFuture<int>(FakeClientCall(response1));
     final responseFuture2 = ResponseFuture<int>(FakeClientCall(response2));
 
     expect(responseFuture1.responseThen((value) => responseFuture2), isA<ResponseFuture<int>>());
-    expect(await responseFuture1.responseThen((value) => responseFuture2), 1);
+    expect(await responseFuture1, response1);
+    expect(await responseFuture1.responseThen((value) => responseFuture2), response2);
   });
 }

--- a/test/client_tests/response_future_test.dart
+++ b/test/client_tests/response_future_test.dart
@@ -24,6 +24,11 @@ void main() {
     expect(responseFuture.responseThen((p1) => p1), isA<ResponseFuture>());
 
     expect(await responseFuture.responseThen((p1) => p1 * 2), response * 2);
+    expect(
+        await responseFuture
+            .responseThen((p1) => p1 * 2)
+            .responseThen((p2) => p2 * 2),
+        response * 2 * 2);
 
     expect(responseFuture.responseThen((p1) => p1), isA<ResponseFuture>());
     expect(responseFuture.then((p1) => '2'), isA<Future>());
@@ -48,8 +53,10 @@ void main() {
     final responseFuture1 = ResponseFuture<int>(FakeClientCall(response1));
     final responseFuture2 = ResponseFuture<int>(FakeClientCall(response2));
 
-    expect(responseFuture1.responseThen((value) => responseFuture2), isA<ResponseFuture<int>>());
+    expect(responseFuture1.responseThen((value) => responseFuture2),
+        isA<ResponseFuture<int>>());
     expect(await responseFuture1, response1);
-    expect(await responseFuture1.responseThen((value) => responseFuture2), response2);
+    expect(await responseFuture1.responseThen((value) => responseFuture2),
+        response2);
   });
 }

--- a/test/client_tests/response_future_test.dart
+++ b/test/client_tests/response_future_test.dart
@@ -1,0 +1,54 @@
+import 'package:grpc/grpc.dart';
+import 'package:grpc/src/client/common.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../src/client_utils.dart';
+
+class FakeClientCall extends Fake implements ClientCall<dynamic, int> {
+  final int _response;
+
+  FakeClientCall(this._response);
+
+  @override
+  Stream<int> get response => Stream.value(_response);
+}
+
+void main() {
+  test('ResponseFuture responseThen returns ResponseFuture', () async {
+    final response = 1;
+    final responseFuture = ResponseFuture(FakeClientCall(response));
+
+    expect(await responseFuture, response);
+    expect(await responseFuture.responseThen((p1) => p1), response);
+    expect(responseFuture.responseThen((p1) => p1), isA<ResponseFuture>());
+
+    expect(await responseFuture.responseThen((p1) => p1 * 2), response * 2);
+
+    expect(responseFuture.responseThen((p1) => p1), isA<ResponseFuture>());
+    expect(responseFuture.then((p1) => '2'), isA<Future>());
+
+    expect(await responseFuture.responseThen((p1) => p1), response);
+    expect(await responseFuture.then((p1) => '2'), '2');
+  });
+
+  test('Support Future after ResponseFuture', () async {
+    final response = 1;
+    final responseFuture = ResponseFuture<int>(FakeClientCall(response));
+
+    final future = Future<String>.value('1');
+    expect(responseFuture.then((value) => future), isA<Future<String>>());
+    expect(await responseFuture.then((value) => future), '1');
+  });
+
+  test('Support ResponseFuture after ResponseFuture', () async {
+    final response1 = 1;
+    final response2 = 1;
+
+    final responseFuture1 = ResponseFuture<int>(FakeClientCall(response1));
+    final responseFuture2 = ResponseFuture<int>(FakeClientCall(response2));
+
+    expect(responseFuture1.responseThen((value) => responseFuture2), isA<ResponseFuture<int>>());
+    expect(await responseFuture1.responseThen((value) => responseFuture2), 1);
+  });
+}


### PR DESCRIPTION
Same as https://github.com/grpc/grpc-dart/pull/419 but rebased on master.

Also adds `responseTransform` to chain StreamTransformers to a ResponseStream.