### PR TITLE
Ensure server's security context is used for the server.

### DIFF
--- a/test/client_certificate_test.dart
+++ b/test/client_certificate_test.dart
@@ -81,7 +81,7 @@ Future<void> main() async {
 
 Future<Server> _setUpServer([bool requireClientCertificate = false]) async {
   final server = Server([EchoService()]);
-  final serverContext = SecurityContextChannelCredentials.baseSecurityContext();
+  final serverContext = SecurityContextServerCredentials.baseSecurityContext();
   serverContext.useCertificateChain('test/data/localhost.crt');
   serverContext.usePrivateKey('test/data/localhost.key');
   serverContext.setTrustedCertificates('test/data/localhost.crt');


### PR DESCRIPTION
Use of client's context for the server results in the server not able to correctly handle ALPN selection: server is not able to request http2(the only one that grpc-dart supports) when client offers both http1 and http2, results in client attempting http1 failing to establish the connection.