### PR TITLE
WIP: Allow to intercept responses separately from the whole call

### DIFF
--- a/lib/src/client/channel.dart
+++ b/lib/src/client/channel.dart
@@ -38,7 +38,14 @@ abstract class ClientChannel {
 
   /// Initiates a new RPC on this connection.
   ClientCall<Q, R> createCall<Q, R>(
-      ClientMethod<Q, R> method, Stream<Q> requests, CallOptions options);
+    ClientMethod<Q, R> method,
+    Stream<Q> requests,
+    CallOptions options, {
+    Future<Map<String, String>> Function(Future<Map<String, String>>)?
+        headersTransformer,
+    Future<Map<String, String>> Function(Future<Map<String, String>>)?
+        trailersTransformer,
+  });
 }
 
 /// Auxiliary base class implementing much of ClientChannel.
@@ -83,7 +90,14 @@ abstract class ClientChannelBase implements ClientChannel {
 
   @override
   ClientCall<Q, R> createCall<Q, R>(
-      ClientMethod<Q, R> method, Stream<Q> requests, CallOptions options) {
+    ClientMethod<Q, R> method,
+    Stream<Q> requests,
+    CallOptions options, {
+    Future<Map<String, String>> Function(Future<Map<String, String>>)?
+        headersTransformer,
+    Future<Map<String, String>> Function(Future<Map<String, String>>)?
+        trailersTransformer,
+  }) {
     final call = ClientCall(
         method,
         requests,

--- a/lib/src/client/interceptor.dart
+++ b/lib/src/client/interceptor.dart
@@ -13,11 +13,27 @@ typedef ClientStreamingInvoker<Q, R> = ResponseStream<R> Function(
 /// Invoker either calls next interceptor in the chain or performs the call if it is last in chain.
 /// To modify [CallOptions] make a clone using [CallOptions.mergedWith].
 abstract class ClientInterceptor {
-  // Intercept unary call.
-  // This method is called when client sends single request and receives single response.
+  /// Intercept unary call.
+  ///
+  /// This method is called when client sends single request and receives single response.
   ResponseFuture<R> interceptUnary<Q, R>(ClientMethod<Q, R> method, Q request,
       CallOptions options, ClientUnaryInvoker<Q, R> invoker) {
     return invoker(method, request, options);
+  }
+
+  Future<Map<String, String>> interceptHeaders<Q, R>(
+      ClientMethod<Q, R> method, Future<Map<String, String>> headers) {
+    return headers;
+  }
+
+  Future<Map<String, String>> interceptTrailers<Q, R>(
+      ClientMethod<Q, R> method, Future<Map<String, String>> trailers) {
+    return trailers;
+  }
+
+  Future<R> interceptUnaryResponse<Q, R>(
+      ClientMethod<Q, R> method, Q request, Future<R> response) {
+    return response;
   }
 
   // Intercept streaming call.
@@ -28,5 +44,10 @@ abstract class ClientInterceptor {
       CallOptions options,
       ClientStreamingInvoker<Q, R> invoker) {
     return invoker(method, requests, options);
+  }
+
+  Stream<R> interceptStreamingResponse<Q, R>(
+      ClientMethod<Q, R> method, Stream<Q> request, Stream<R> response) {
+    return response;
   }
 }

--- a/test/client_tests/client_interceptor_test.dart
+++ b/test/client_tests/client_interceptor_test.dart
@@ -38,6 +38,24 @@ class FakeInterceptor implements ClientInterceptor {
   }
 
   @override
+  Future<Map<String, String>> interceptHeaders<Q, R>(
+      ClientMethod<Q, R> method, Future<Map<String, String>> headers) {
+    return headers;
+  }
+
+  @override
+  Future<Map<String, String>> interceptTrailers<Q, R>(
+      ClientMethod<Q, R> method, Future<Map<String, String>> trailers) {
+    return trailers;
+  }
+
+  @override
+  Future<R> interceptUnaryResponse<Q, R>(
+      ClientMethod<Q, R> method, Q request, Future<R> response) {
+    return response;
+  }
+
+  @override
   ResponseStream<R> interceptStreaming<Q, R>(
       ClientMethod<Q, R> method,
       Stream<Q> requests,
@@ -50,6 +68,12 @@ class FakeInterceptor implements ClientInterceptor {
         : requests;
 
     return invoker(method, requestStream, _inject(options));
+  }
+
+  @override
+  Stream<R> interceptStreamingResponse<Q, R>(
+      ClientMethod<Q, R> method, Stream<Q> request, Stream<R> response) {
+    return response;
   }
 
   CallOptions _inject(CallOptions options) {


### PR DESCRIPTION
An alternative solution to https://github.com/grpc/grpc-dart/issues/413 without introducing `ResponseFuture` wrapping/chaining.