### PR TITLE
Fixing crash when sending headers to closed client (#558)

### DIFF
--- a/lib/src/server/handler.dart
+++ b/lib/src/server/handler.dart
@@ -358,7 +358,9 @@ class ServerHandler_ extends ServiceCall {
     final outgoingTrailers = <Header>[];
     outgoingTrailersMap.forEach((key, value) =>
         outgoingTrailers.add(Header(ascii.encode(key), utf8.encode(value))));
-    _stream.sendHeaders(outgoingTrailers, endStream: true);
+    try {
+      _stream.sendHeaders(outgoingTrailers, endStream: true);
+    } catch (error) {}
     // We're done!
     _cancelResponseSubscription();
     _sinkIncoming();


### PR DESCRIPTION
Fix for #558 