### PR TITLE
Add onConnectionStateChanged on ClientConnection

### DIFF
--- a/lib/src/client/connection.dart
+++ b/lib/src/client/connection.dart
@@ -57,4 +57,7 @@ abstract class ClientConnection {
   /// All open calls are terminated immediately, and no further calls may be
   /// made on this connection.
   Future<void> terminate();
+
+  void Function(ConnectionState prevState, ConnectionState state)?
+      onConnectionStateChanged;
 }

--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -17,6 +17,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:grpc/grpc.dart';
 import 'package:http2/transport.dart';
 import 'package:meta/meta.dart';
 
@@ -42,6 +43,10 @@ class Http2ClientConnection implements connection.ClientConnection {
   final ChannelOptions options;
 
   connection.ConnectionState _state = ConnectionState.idle;
+
+  @override
+  void Function(ConnectionState prevState, ConnectionState state)?
+      onConnectionStateChanged;
 
   @visibleForTesting
   void Function(Http2ClientConnection connection)? onStateChanged;
@@ -213,7 +218,9 @@ class Http2ClientConnection implements connection.ClientConnection {
   }
 
   void _setState(ConnectionState state) {
+    final oldState = _state;
     _state = state;
+    onConnectionStateChanged?.call(oldState, state);
     onStateChanged?.call(this);
   }
 


### PR DESCRIPTION
This PR adds a callback on `ClientConnection` to get updates when the `ConnectionState` changes.

Usage:
```dart
final conn = await clientChannel.getConnection();
conn.onConnectionStateChanged = (ConnectionState prevState, ConnectionState state) {
  // ... do whatever.
}
```

This is a first solution for issue #428. It's not perfect yet and could be improved upon, I'm open to critics/suggestions.

## 👀 Why is it important?

A modern app (particularly GUI) should be able to provide feedback to user related to the state of the connection. We don't want the user to wait until they interact to tell them that "oh actually the connection is down", we need to tell them as soon as possible.

## 🛠 Possible improvements

1. Maybe we could set that callback as a parameter of the `ClientChannel` ? That way we wouldn't have to force the creation of the connection just to set it.

2. Is the previous state necessary ? I put it there as I feel like it's important, going from `idle` to `connected` is not the same as going from `transientFailure` to `connected`. But we could also leave that to the user to store the previous state 🤔