### PR TITLE
Expose onConnectionStateChanged for channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.0-dev
+
+* Expose a stream for connection state changes on ClientChannel to address
+  [#428](https://github.com/grpc/grpc-dart/issues/428).
+  This allows users to react to state changes in the connection.
+
 ## 3.0.2
 
 * Fix compilation on the Web with DDC.

--- a/lib/src/client/channel.dart
+++ b/lib/src/client/channel.dart
@@ -42,7 +42,7 @@ abstract class ClientChannel {
 
   /// Stream to listen for connection changes
   /// 
-  /// This returns a broadcast stream that can be listened to for conenction changes.
+  /// This returns a broadcast stream that can be listened to for connection changes.
   Stream<ConnectionState> get onConnectionStateChanged;
 }
 

--- a/lib/src/client/channel.dart
+++ b/lib/src/client/channel.dart
@@ -40,7 +40,7 @@ abstract class ClientChannel {
   ClientCall<Q, R> createCall<Q, R>(
       ClientMethod<Q, R> method, Stream<Q> requests, CallOptions options);
 
-  /// Stream to listen for connection changes
+  /// Stream of connection state changes
   /// 
   /// This returns a broadcast stream that can be listened to for connection changes.
   Stream<ConnectionState> get onConnectionStateChanged;
@@ -52,6 +52,10 @@ abstract class ClientChannelBase implements ClientChannel {
   late ClientConnection _connection;
   var _connected = false;
   bool _isShutdown = false;
+  //  Closing is done in Http2ClientChannel
+  // ignore: close_sinks
+  final StreamController<ConnectionState> connectionStateStreamController =
+      StreamController.broadcast();
 
   ClientChannelBase();
 

--- a/lib/src/client/channel.dart
+++ b/lib/src/client/channel.dart
@@ -39,6 +39,11 @@ abstract class ClientChannel {
   /// Initiates a new RPC on this connection.
   ClientCall<Q, R> createCall<Q, R>(
       ClientMethod<Q, R> method, Stream<Q> requests, CallOptions options);
+
+  /// Stream to listen for connection changes
+  /// 
+  /// This returns a broadcast stream that can be listened to for conenction changes.
+  Stream<ConnectionState> get onConnectionStateChanged;
 }
 
 /// Auxiliary base class implementing much of ClientChannel.

--- a/lib/src/client/connection.dart
+++ b/lib/src/client/connection.dart
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:meta/meta.dart';
-
 import 'call.dart';
 
 import 'transport/transport.dart';
@@ -64,9 +62,5 @@ abstract class ClientConnection {
   /// invoked when the state of this connection changes.
   // no need for this to be public,
   // but needed in the actual implementations
-  @protected
-  void Function(ConnectionState)? onStateChangedCb;
-  set onStateChanged(void Function(ConnectionState) cb) {
-    onStateChangedCb = cb;
-  }
+  set onStateChanged(void Function(ConnectionState) cb);
 }

--- a/lib/src/client/connection.dart
+++ b/lib/src/client/connection.dart
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:meta/meta.dart';
+
 import 'call.dart';
 
 import 'transport/transport.dart';
@@ -57,4 +59,14 @@ abstract class ClientConnection {
   /// All open calls are terminated immediately, and no further calls may be
   /// made on this connection.
   Future<void> terminate();
+
+  /// Set state change listener for this connection. The given callback will be
+  /// invoked when the state of this connection changes.
+  // no need for this to be public,
+  // but needed in the actual implementations
+  @protected
+  void Function(ConnectionState)? onStateChangedCb;
+  set onStateChanged(void Function(ConnectionState) cb) {
+    onStateChangedCb = cb;
+  }
 }

--- a/lib/src/client/http2_channel.dart
+++ b/lib/src/client/http2_channel.dart
@@ -39,11 +39,11 @@ class ClientChannel extends ClientChannelBase {
   @override
   ClientConnection createConnection() {
     final connection = Http2ClientConnection(host, port, options);
-    connection.onStateChanged = (c) {
+    connection.onStateChanged = (state) {
       if (connectionStateStreamController.isClosed) {
         return;
       }
-      connectionStateStreamController.add(c.state);
+      connectionStateStreamController.add(state);
     };
     return connection;
   }
@@ -60,11 +60,11 @@ class ClientTransportConnectorChannel extends ClientChannelBase {
   ClientConnection createConnection() {
     final connection = Http2ClientConnection.fromClientTransportConnector(
         transportConnector, options);
-    connection.onStateChanged = (c) {
+    connection.onStateChanged = (state) {
       if (connectionStateStreamController.isClosed) {
         return;
       }
-      connectionStateStreamController.add(c.state);
+      connectionStateStreamController.add(state);
     };
     return connection;
   }

--- a/lib/src/client/http2_channel.dart
+++ b/lib/src/client/http2_channel.dart
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
-
 import 'channel.dart';
 import 'client_transport_connector.dart';
 import 'connection.dart';
@@ -49,26 +47,6 @@ class ClientChannel extends ClientChannelBase {
     };
     return connection;
   }
-
-  @override
-  Future<void> shutdown() {
-    return super.shutdown()
-    .whenComplete(() {
-      connectionStateStreamController.close();
-    });
-  }
-
-  @override
-  Future<void> terminate() {
-    return super.terminate()
-    .whenComplete(() {
-      connectionStateStreamController.close();
-    });
-  }
-
-  @override
-  Stream<ConnectionState> get onConnectionStateChanged =>
-      connectionStateStreamController.stream;
 }
 
 class ClientTransportConnectorChannel extends ClientChannelBase {
@@ -90,26 +68,4 @@ class ClientTransportConnectorChannel extends ClientChannelBase {
     };
     return connection;
   }
-
-  @override
-  Future<void> shutdown() {
-    return super.shutdown()
-    .then((value) {
-      connectionStateStreamController.close();
-      return value;
-    });
-  }
-
-  @override
-  Future<void> terminate() {
-    return super.terminate()
-    .then((value) {
-      connectionStateStreamController.close();
-      return value;
-    });
-  }
-
-  @override
-  Stream<ConnectionState> get onConnectionStateChanged =>
-      connectionStateStreamController.stream;
 }

--- a/lib/src/client/http2_channel.dart
+++ b/lib/src/client/http2_channel.dart
@@ -33,8 +33,6 @@ class ClientChannel extends ClientChannelBase {
   final Object host;
   final int port;
   final ChannelOptions options;
-  final StreamController<ConnectionState> connectionStateStreamController =
-      StreamController.broadcast();
 
   ClientChannel(this.host,
       {this.port = 443, this.options = const ChannelOptions()})
@@ -55,18 +53,16 @@ class ClientChannel extends ClientChannelBase {
   @override
   Future<void> shutdown() {
     return super.shutdown()
-    .then((value) {
+    .whenComplete(() {
       connectionStateStreamController.close();
-      return value;
     });
   }
 
   @override
   Future<void> terminate() {
     return super.terminate()
-    .then((value) {
+    .whenComplete(() {
       connectionStateStreamController.close();
-      return value;
     });
   }
 
@@ -78,8 +74,6 @@ class ClientChannel extends ClientChannelBase {
 class ClientTransportConnectorChannel extends ClientChannelBase {
   final ClientTransportConnector transportConnector;
   final ChannelOptions options;
-  final StreamController<ConnectionState> connectionStateStreamController =
-      StreamController.broadcast();
 
   ClientTransportConnectorChannel(this.transportConnector,
       {this.options = const ChannelOptions()});

--- a/lib/src/client/http2_channel.dart
+++ b/lib/src/client/http2_channel.dart
@@ -37,16 +37,8 @@ class ClientChannel extends ClientChannelBase {
       : super();
 
   @override
-  ClientConnection createConnection() {
-    final connection = Http2ClientConnection(host, port, options);
-    connection.onStateChanged = (state) {
-      if (connectionStateStreamController.isClosed) {
-        return;
-      }
-      connectionStateStreamController.add(state);
-    };
-    return connection;
-  }
+  ClientConnection createConnection() =>
+      Http2ClientConnection(host, port, options);
 }
 
 class ClientTransportConnectorChannel extends ClientChannelBase {
@@ -57,15 +49,7 @@ class ClientTransportConnectorChannel extends ClientChannelBase {
       {this.options = const ChannelOptions()});
 
   @override
-  ClientConnection createConnection() {
-    final connection = Http2ClientConnection.fromClientTransportConnector(
-        transportConnector, options);
-    connection.onStateChanged = (state) {
-      if (connectionStateStreamController.isClosed) {
-        return;
-      }
-      connectionStateStreamController.add(state);
-    };
-    return connection;
-  }
+  ClientConnection createConnection() =>
+      Http2ClientConnection.fromClientTransportConnector(
+          transportConnector, options);
 }

--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -30,7 +30,7 @@ import 'transport/http2_credentials.dart';
 import 'transport/http2_transport.dart';
 import 'transport/transport.dart';
 
-class Http2ClientConnection extends connection.ClientConnection {
+class Http2ClientConnection implements connection.ClientConnection {
   static final _methodPost = Header.ascii(':method', 'POST');
   static final _schemeHttp = Header.ascii(':scheme', 'http');
   static final _schemeHttps = Header.ascii(':scheme', 'https');
@@ -41,6 +41,8 @@ class Http2ClientConnection extends connection.ClientConnection {
   final ChannelOptions options;
 
   connection.ConnectionState _state = ConnectionState.idle;
+
+  void Function(connection.ConnectionState)? onStateChanged;
 
   final _pendingCalls = <ClientCall>[];
 
@@ -211,7 +213,7 @@ class Http2ClientConnection extends connection.ClientConnection {
 
   void _setState(ConnectionState state) {
     _state = state;
-    onStateChangedCb?.call(state);
+    onStateChanged?.call(state);
   }
 
   void _handleIdleTimeout() {

--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -43,7 +43,6 @@ class Http2ClientConnection implements connection.ClientConnection {
 
   connection.ConnectionState _state = ConnectionState.idle;
 
-  @visibleForTesting
   void Function(Http2ClientConnection connection)? onStateChanged;
   final _pendingCalls = <ClientCall>[];
 

--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -18,7 +18,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:http2/transport.dart';
-import 'package:meta/meta.dart';
 
 import '../shared/codec.dart';
 import '../shared/timeout.dart';
@@ -31,7 +30,7 @@ import 'transport/http2_credentials.dart';
 import 'transport/http2_transport.dart';
 import 'transport/transport.dart';
 
-class Http2ClientConnection implements connection.ClientConnection {
+class Http2ClientConnection extends connection.ClientConnection {
   static final _methodPost = Header.ascii(':method', 'POST');
   static final _schemeHttp = Header.ascii(':scheme', 'http');
   static final _schemeHttps = Header.ascii(':scheme', 'https');
@@ -43,7 +42,6 @@ class Http2ClientConnection implements connection.ClientConnection {
 
   connection.ConnectionState _state = ConnectionState.idle;
 
-  void Function(Http2ClientConnection connection)? onStateChanged;
   final _pendingCalls = <ClientCall>[];
 
   final ClientTransportConnector _transportConnector;
@@ -213,7 +211,7 @@ class Http2ClientConnection implements connection.ClientConnection {
 
   void _setState(ConnectionState state) {
     _state = state;
-    onStateChanged?.call(this);
+    onStateChangedCb?.call(state);
   }
 
   void _handleIdleTimeout() {

--- a/lib/src/client/transport/xhr_transport.dart
+++ b/lib/src/client/transport/xhr_transport.dart
@@ -144,7 +144,7 @@ class XhrTransportStream implements GrpcTransportStream {
   }
 }
 
-class XhrClientConnection extends ClientConnection {
+class XhrClientConnection implements ClientConnection {
   final Uri uri;
 
   final _requests = <XhrTransportStream>{};
@@ -217,6 +217,11 @@ class XhrClientConnection extends ClientConnection {
 
   @override
   Future<void> shutdown() async {}
+
+  @override
+  set onStateChanged(void Function(ConnectionState) cb) {
+    // Do nothing.
+  }
 }
 
 MapEntry<String, String>? _getContentTypeHeader(Map<String, String> metadata) {

--- a/lib/src/client/web_channel.dart
+++ b/lib/src/client/web_channel.dart
@@ -27,7 +27,4 @@ class GrpcWebClientChannel extends ClientChannelBase {
   ClientConnection createConnection() {
     return XhrClientConnection(uri);
   }
-
-  @override
-  Stream<ConnectionState> get onConnectionStateChanged => throw UnimplementedError();
 }

--- a/lib/src/client/web_channel.dart
+++ b/lib/src/client/web_channel.dart
@@ -27,4 +27,7 @@ class GrpcWebClientChannel extends ClientChannelBase {
   ClientConnection createConnection() {
     return XhrClientConnection(uri);
   }
+
+  @override
+  Stream<ConnectionState> get onConnectionStateChanged => throw UnimplementedError();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: grpc
 description: Dart implementation of gRPC, a high performance, open-source universal RPC framework.
 
-version: 3.0.2
+version: 3.1.0-dev
 
 repository: https://github.com/grpc/grpc-dart
 

--- a/test/client_handles_bad_connections_test.dart
+++ b/test/client_handles_bad_connections_test.dart
@@ -41,8 +41,6 @@ class TestService extends grpc.Service {
 
 class FixedConnectionClientChannel extends ClientChannelBase {
   final Http2ClientConnection clientConnection;
-  final StreamController<ConnectionState> connectionStateStreamController =
-      StreamController.broadcast();
   List<grpc.ConnectionState> states = <grpc.ConnectionState>[];
   FixedConnectionClientChannel(this.clientConnection) {
     clientConnection.onStateChanged = (c) {

--- a/test/client_handles_bad_connections_test.dart
+++ b/test/client_handles_bad_connections_test.dart
@@ -59,10 +59,6 @@ class FixedConnectionClientChannel extends ClientChannelBase {
   }
   @override
   ClientConnection createConnection() => clientConnection;
-
-  @override
-  Stream<ConnectionState> get onConnectionStateChanged =>
-      connectionStateStreamController.stream;
 }
 
 Future<void> main() async {

--- a/test/client_handles_bad_connections_test.dart
+++ b/test/client_handles_bad_connections_test.dart
@@ -43,16 +43,6 @@ class FixedConnectionClientChannel extends ClientChannelBase {
   final Http2ClientConnection clientConnection;
   List<grpc.ConnectionState> states = <grpc.ConnectionState>[];
   FixedConnectionClientChannel(this.clientConnection) {
-    clientConnection.onStateChanged = (state) {
-      if (connectionStateStreamController.isClosed) {
-        return;
-      }
-      connectionStateStreamController.add(state);
-      if (state == ConnectionState.shutdown) {
-        connectionStateStreamController.close();
-      }
-    };
-
     onConnectionStateChanged.listen((state) {
       states.add(state);
     });

--- a/test/client_handles_bad_connections_test.dart
+++ b/test/client_handles_bad_connections_test.dart
@@ -43,12 +43,12 @@ class FixedConnectionClientChannel extends ClientChannelBase {
   final Http2ClientConnection clientConnection;
   List<grpc.ConnectionState> states = <grpc.ConnectionState>[];
   FixedConnectionClientChannel(this.clientConnection) {
-    clientConnection.onStateChanged = (c) {
+    clientConnection.onStateChanged = (state) {
       if (connectionStateStreamController.isClosed) {
         return;
       }
-      connectionStateStreamController.add(c.state);
-      if (c.state == ConnectionState.shutdown) {
+      connectionStateStreamController.add(state);
+      if (state == ConnectionState.shutdown) {
         connectionStateStreamController.close();
       }
     };

--- a/test/client_tests/client_test.dart
+++ b/test/client_tests/client_test.dart
@@ -472,45 +472,63 @@ void main() {
     );
   }
 
+  test('Connection states are reported', () async {
+    final connectionStates = <ConnectionState>[];
+    harness.channel.onConnectionStateChanged.listen((state) {
+      connectionStates.add(state);
+    }
+    ,onDone: () {
+      expect(
+        connectionStates, [
+          ConnectionState.connecting,
+          ConnectionState.ready,
+          ConnectionState.shutdown
+        ]);
+    });
+
+    await makeUnaryCall();
+  });
+
   test('Connection errors are reported', () async {
     final connectionStates = <ConnectionState>[];
     harness.connection!.connectionError = 'Connection error';
-    harness.connection!.onStateChanged = (connection) {
-      final state = connection.state;
+    harness.channel.onConnectionStateChanged.listen((state) {
       connectionStates.add(state);
-    };
+    }
+    ,onDone: () {
+      expect(
+        connectionStates, [ConnectionState.connecting, ConnectionState.idle]);
+    });
 
     final expectedException =
         GrpcError.unavailable('Error connecting: Connection error');
 
     await harness.expectThrows(
         harness.client.unary(dummyValue), expectedException);
-
-    expect(
-        connectionStates, [ConnectionState.connecting, ConnectionState.idle]);
   });
 
   test('Connections time out if idle', () async {
     final done = Completer();
     final connectionStates = <ConnectionState>[];
-    harness.connection!.onStateChanged = (connection) {
-      final state = connection.state;
+    harness.channel.onConnectionStateChanged.listen((state) {
       connectionStates.add(state);
       if (state == ConnectionState.idle) done.complete();
-    };
+    }
+    ,onDone: () async {
+      expect(
+        connectionStates, [ConnectionState.connecting, ConnectionState.ready]);
+      await done.future;
+      expect(connectionStates, [
+        ConnectionState.connecting,
+        ConnectionState.ready,
+        ConnectionState.idle
+      ]);
+    });
 
     harness.channelOptions.idleTimeout = const Duration(microseconds: 10);
 
     await makeUnaryCall();
     harness.signalIdle();
-    expect(
-        connectionStates, [ConnectionState.connecting, ConnectionState.ready]);
-    await done.future;
-    expect(connectionStates, [
-      ConnectionState.connecting,
-      ConnectionState.ready,
-      ConnectionState.idle
-    ]);
   });
 
   test('Default reconnect backoff backs off', () {

--- a/test/client_tests/client_test.dart
+++ b/test/client_tests/client_test.dart
@@ -476,14 +476,12 @@ void main() {
     final connectionStates = <ConnectionState>[];
     harness.channel.onConnectionStateChanged.listen((state) {
       connectionStates.add(state);
-    }
-    ,onDone: () {
-      expect(
-        connectionStates, [
-          ConnectionState.connecting,
-          ConnectionState.ready,
-          ConnectionState.shutdown
-        ]);
+    }, onDone: () {
+      expect(connectionStates, [
+        ConnectionState.connecting,
+        ConnectionState.ready,
+        ConnectionState.shutdown
+      ]);
     });
 
     await makeUnaryCall();
@@ -494,10 +492,9 @@ void main() {
     harness.connection!.connectionError = 'Connection error';
     harness.channel.onConnectionStateChanged.listen((state) {
       connectionStates.add(state);
-    }
-    ,onDone: () {
+    }, onDone: () {
       expect(
-        connectionStates, [ConnectionState.connecting, ConnectionState.idle]);
+          connectionStates, [ConnectionState.connecting, ConnectionState.idle]);
     });
 
     final expectedException =
@@ -513,10 +510,9 @@ void main() {
     harness.channel.onConnectionStateChanged.listen((state) {
       connectionStates.add(state);
       if (state == ConnectionState.idle) done.complete();
-    }
-    ,onDone: () async {
-      expect(
-        connectionStates, [ConnectionState.connecting, ConnectionState.ready]);
+    }, onDone: () async {
+      expect(connectionStates,
+          [ConnectionState.connecting, ConnectionState.ready]);
       await done.future;
       expect(connectionStates, [
         ConnectionState.connecting,

--- a/test/client_tests/client_transport_connector_test.dart
+++ b/test/client_tests/client_transport_connector_test.dart
@@ -356,13 +356,12 @@ void main() {
     harness.connection!.connectionError = 'Connection error';
     harness.channel.onConnectionStateChanged.listen((state) {
       connectionStates.add(state);
-    }
-    ,onDone: () async {
+    }, onDone: () async {
       await harness.expectThrows(
-        harness.client.unary(dummyValue), expectedException);
+          harness.client.unary(dummyValue), expectedException);
 
-    expect(
-        connectionStates, [ConnectionState.connecting, ConnectionState.idle]);
+      expect(
+          connectionStates, [ConnectionState.connecting, ConnectionState.idle]);
     });
   });
 
@@ -372,10 +371,9 @@ void main() {
     harness.channel.onConnectionStateChanged.listen((state) {
       connectionStates.add(state);
       if (state == ConnectionState.idle) done.complete();
-    }
-    ,onDone: () async {
-      expect(
-        connectionStates, [ConnectionState.connecting, ConnectionState.ready]);
+    }, onDone: () async {
+      expect(connectionStates,
+          [ConnectionState.connecting, ConnectionState.ready]);
       await done.future;
       expect(connectionStates, [
         ConnectionState.connecting,

--- a/test/round_trip_test.dart
+++ b/test/round_trip_test.dart
@@ -54,15 +54,6 @@ class FixedConnectionClientChannel extends ClientChannelBase {
   final Http2ClientConnection clientConnection;
   List<ConnectionState> states = <ConnectionState>[];
   FixedConnectionClientChannel(this.clientConnection) {
-    clientConnection.onStateChanged = (state) {
-      if (connectionStateStreamController.isClosed) {
-        return;
-      }
-      connectionStateStreamController.add(state);
-      if (state == ConnectionState.shutdown) {
-        connectionStateStreamController.close();
-      }
-    };
     onConnectionStateChanged.listen((state) => states.add(state));
   }
   @override

--- a/test/round_trip_test.dart
+++ b/test/round_trip_test.dart
@@ -54,12 +54,12 @@ class FixedConnectionClientChannel extends ClientChannelBase {
   final Http2ClientConnection clientConnection;
   List<ConnectionState> states = <ConnectionState>[];
   FixedConnectionClientChannel(this.clientConnection) {
-    clientConnection.onStateChanged = (c) {
+    clientConnection.onStateChanged = (state) {
       if (connectionStateStreamController.isClosed) {
         return;
       }
-      connectionStateStreamController.add(c.state);
-      if (c.state == ConnectionState.shutdown) {
+      connectionStateStreamController.add(state);
+      if (state == ConnectionState.shutdown) {
         connectionStateStreamController.close();
       }
     };

--- a/test/round_trip_test.dart
+++ b/test/round_trip_test.dart
@@ -53,8 +53,6 @@ class TestServiceWithOnMetadataException extends TestService {
 class FixedConnectionClientChannel extends ClientChannelBase {
   final Http2ClientConnection clientConnection;
   List<ConnectionState> states = <ConnectionState>[];
-  final StreamController<ConnectionState> connectionStateStreamController =
-      StreamController.broadcast();
   FixedConnectionClientChannel(this.clientConnection) {
     clientConnection.onStateChanged = (c) {
       if (connectionStateStreamController.isClosed) {

--- a/test/round_trip_test.dart
+++ b/test/round_trip_test.dart
@@ -67,10 +67,6 @@ class FixedConnectionClientChannel extends ClientChannelBase {
   }
   @override
   ClientConnection createConnection() => clientConnection;
-
-  @override
-  Stream<ConnectionState> get onConnectionStateChanged =>
-      connectionStateStreamController.stream;
 }
 
 Future<void> main() async {

--- a/test/timeline_test.dart
+++ b/test/timeline_test.dart
@@ -73,10 +73,6 @@ class FixedConnectionClientChannel extends ClientChannelBase {
   }
   @override
   ClientConnection createConnection() => clientConnection;
-
-  @override
-  Stream<ConnectionState> get onConnectionStateChanged =>
-      connectionStateStreamController.stream;
 }
 
 class FakeTimelineTask extends Fake implements TimelineTask {

--- a/test/timeline_test.dart
+++ b/test/timeline_test.dart
@@ -59,12 +59,12 @@ class FixedConnectionClientChannel extends ClientChannelBase {
   final Http2ClientConnection clientConnection;
   List<ConnectionState> states = <ConnectionState>[];
   FixedConnectionClientChannel(this.clientConnection) {
-    clientConnection.onStateChanged = (c) {
+    clientConnection.onStateChanged = (state) {
       if (connectionStateStreamController.isClosed) {
         return;
       }
-      connectionStateStreamController.add(c.state);
-      if (c.state == ConnectionState.shutdown) {
+      connectionStateStreamController.add(state);
+      if (state == ConnectionState.shutdown) {
         connectionStateStreamController.close();
       }
     };

--- a/test/timeline_test.dart
+++ b/test/timeline_test.dart
@@ -59,16 +59,6 @@ class FixedConnectionClientChannel extends ClientChannelBase {
   final Http2ClientConnection clientConnection;
   List<ConnectionState> states = <ConnectionState>[];
   FixedConnectionClientChannel(this.clientConnection) {
-    clientConnection.onStateChanged = (state) {
-      if (connectionStateStreamController.isClosed) {
-        return;
-      }
-      connectionStateStreamController.add(state);
-      if (state == ConnectionState.shutdown) {
-        connectionStateStreamController.close();
-      }
-    };
-
     onConnectionStateChanged.listen((state) => states.add(state));
   }
   @override

--- a/test/timeline_test.dart
+++ b/test/timeline_test.dart
@@ -57,8 +57,6 @@ class TestService extends Service {
 
 class FixedConnectionClientChannel extends ClientChannelBase {
   final Http2ClientConnection clientConnection;
-  final StreamController<ConnectionState> connectionStateStreamController =
-      StreamController.broadcast();
   List<ConnectionState> states = <ConnectionState>[];
   FixedConnectionClientChannel(this.clientConnection) {
     clientConnection.onStateChanged = (c) {


### PR DESCRIPTION
This offers a Stream<ConnectionState> on channels. Only for Http2Channel, not for web usage.

Usage:
clientChannel.onConnectionStateChanged.listen(...)

This is an alternative to #563. Only merge one of these.