### PR TITLE
Fix settings-frame waiting hack

### DIFF
--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -79,10 +79,7 @@ class Http2ClientConnection implements connection.ClientConnection {
     final connection = await _transportConnector.connect();
     _transportConnector.done.then((_) => _abandonConnection());
 
-    // Give the settings settings-frame a bit of time to arrive.
-    // TODO(sigurdm): This is a hack. The http2 package should expose a way of
-    // waiting for the settings frame to arrive.
-    await Future.delayed(_estimatedRoundTripTime);
+    await connection.onInitialPeerSettingsReceived;
 
     if (_state == ConnectionState.shutdown) {
       _transportConnector.shutdown();


### PR DESCRIPTION
In https://github.com/dart-lang/http2/commit/9814696a101067c9db9c1b3cc071bfb2c3e44748 , @mraleph Added onInitialPeerSettingsReceived, making it no longer necessary to rely on time hack to wait for settings frame.