### PR TITLE
Custom Error Handling for Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 3.1.1-dev
 
 * Require Dart 2.17 or greater.
-* Fix issue [#51](https://github.com/grpc/grpc-dart/issues/51), add support for response error handling.
+* Fix issue [#51](https://github.com/grpc/grpc-dart/issues/51), add support for custom error handling.
 
 ## 3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.1.1-dev
 
 * Require Dart 2.17 or greater.
+* Fix issue [#51](https://github.com/grpc/grpc-dart/issues/51), add support for response error handling.
 
 ## 3.1.0
 

--- a/example/helloworld/bin/server.dart
+++ b/example/helloworld/bin/server.dart
@@ -25,10 +25,9 @@ class GreeterService extends GreeterServiceBase {
 }
 
 Future<void> main(List<String> args) async {
-  final server = Server(
-    [GreeterService()],
-    const <Interceptor>[],
-    CodecRegistry(codecs: const [GzipCodec(), IdentityCodec()]),
+  final server = Server.create(
+    services: [GreeterService()],
+    codecRegistry: CodecRegistry(codecs: const [GzipCodec(), IdentityCodec()]),
   );
   await server.serve(port: 50051);
   print('Server listening on port ${server.port}...');

--- a/example/helloworld/bin/unix_server.dart
+++ b/example/helloworld/bin/unix_server.dart
@@ -29,7 +29,7 @@ class GreeterService extends GreeterServiceBase {
 Future<void> main(List<String> args) async {
   final udsAddress =
       InternetAddress('localhost', type: InternetAddressType.unix);
-  final server = Server([GreeterService()]);
+  final server = Server.create(services: [GreeterService()]);
   await server.serve(address: udsAddress);
   print('Start UNIX Server @localhost...');
 }

--- a/example/metadata/lib/src/server.dart
+++ b/example/metadata/lib/src/server.dart
@@ -78,7 +78,7 @@ class MetadataService extends MetadataServiceBase {
 
 class Server {
   Future<void> main(List<String> args) async {
-    final server = grpc.Server([MetadataService()]);
+    final server = grpc.Server.create(services: [MetadataService()]);
     await server.serve(port: 8080);
     print('Server listening on port ${server.port}...');
   }

--- a/example/route_guide/lib/src/server.dart
+++ b/example/route_guide/lib/src/server.dart
@@ -144,7 +144,7 @@ class RouteGuideService extends RouteGuideServiceBase {
 
 class Server {
   Future<void> main(List<String> args) async {
-    final server = grpc.Server([RouteGuideService()]);
+    final server = grpc.Server.create(services: [RouteGuideService()]);
     await server.serve(port: 8080);
     print('Server listening on port ${server.port}...');
   }

--- a/interop/bin/server.dart
+++ b/interop/bin/server.dart
@@ -131,7 +131,7 @@ Future<void> main(List<String> args) async {
 
   final services = [TestService()];
 
-  final server = Server(services);
+  final server = Server.create(services: services);
 
   ServerTlsCredentials? tlsCredentials;
   if (arguments['use_tls'] == 'true') {

--- a/lib/src/server/handler.dart
+++ b/lib/src/server/handler.dart
@@ -29,10 +29,12 @@ import 'call.dart';
 import 'interceptor.dart';
 import 'service.dart';
 
+typedef ServiceLookup = Service? Function(String service);
+
 /// Handles an incoming gRPC call.
-class ServerHandlerImpl extends ServiceCall {
+class ServerHandler extends ServiceCall {
   final ServerTransportStream _stream;
-  final Service? Function(String service) _serviceLookup;
+  final ServiceLookup _serviceLookup;
   final List<Interceptor> _interceptors;
   final CodecRegistry? _codecRegistry;
   final Function? _errorHandler;
@@ -62,14 +64,19 @@ class ServerHandlerImpl extends ServiceCall {
   Timer? _timeoutTimer;
   final X509Certificate? _clientCertificate;
 
-  ServerHandlerImpl(
-    this._serviceLookup,
-    this._stream,
-    this._interceptors,
-    this._codecRegistry, [
-    this._clientCertificate,
-    this._errorHandler,
-  ]);
+  ServerHandler({
+    required ServerTransportStream stream,
+    required ServiceLookup serviceLookup,
+    required List<Interceptor> interceptors,
+    required CodecRegistry? codecRegistry,
+    X509Certificate? clientCertificate,
+    Function? errorHandler,
+  })  : _stream = stream,
+        _serviceLookup = serviceLookup,
+        _interceptors = interceptors,
+        _codecRegistry = codecRegistry,
+        _clientCertificate = clientCertificate,
+        _errorHandler = errorHandler;
 
   @override
   DateTime? get deadline => _deadline;

--- a/lib/src/server/handler.dart
+++ b/lib/src/server/handler.dart
@@ -30,7 +30,7 @@ import 'interceptor.dart';
 import 'service.dart';
 
 typedef ServiceLookup = Service? Function(String service);
-typedef GrpcErrorHandler = void Function(GrpcError error, [StackTrace? trace]);
+typedef GrpcErrorHandler = void Function(GrpcError error, StackTrace? trace);
 
 /// Handles an incoming gRPC call.
 class ServerHandler extends ServiceCall {

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -153,6 +153,7 @@ class Server extends ConnectionServer {
     super.services, [
     super.interceptors,
     super.codecRegistry,
+    super.responseErrorHandler,
   ]);
 
   /// The port that the server is listening on, or `null` if the server is not

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -107,10 +107,12 @@ class ConnectionServer {
 
   Service? lookupService(String service) => _services[service];
 
-  Future<void> serveConnection(ServerTransportConnection connection,
-      [X509Certificate? clientCertificate]) async {
+  Future<void> serveConnection(
+    ServerTransportConnection connection, [
+    X509Certificate? clientCertificate,
+  ]) async {
     _connections.add(connection);
-    ServerHandlerImpl? handler;
+    ServerHandler? handler;
     // TODO(jakobr): Set active state handlers, close connection after idle
     // timeout.
     connection.incomingStreams.listen((stream) {
@@ -130,13 +132,18 @@ class ConnectionServer {
   }
 
   @visibleForTesting
-  ServerHandlerImpl serveStream_(ServerTransportStream stream,
-      [X509Certificate? clientCertificate]) {
-    return ServerHandlerImpl(
-      lookupService, stream, _interceptors, _codecRegistry,
+  ServerHandler serveStream_(
+    ServerTransportStream stream, [
+    X509Certificate? clientCertificate,
+  ]) {
+    return ServerHandler(
+      stream: stream,
+      serviceLookup: lookupService,
+      interceptors: _interceptors,
+      codecRegistry: _codecRegistry,
       // ignore: unnecessary_cast
-      clientCertificate as io_bits.X509Certificate?,
-      _errorHandler,
+      clientCertificate: clientCertificate as io_bits.X509Certificate?,
+      errorHandler: _errorHandler,
     )..handle();
   }
 }
@@ -237,16 +244,18 @@ class Server extends ConnectionServer {
 
   @override
   @visibleForTesting
-  ServerHandlerImpl serveStream_(ServerTransportStream stream,
-      [X509Certificate? clientCertificate]) {
-    return ServerHandlerImpl(
-      lookupService,
-      stream,
-      _interceptors,
-      _codecRegistry,
+  ServerHandler serveStream_(
+    ServerTransportStream stream, [
+    X509Certificate? clientCertificate,
+  ]) {
+    return ServerHandler(
+      stream: stream,
+      serviceLookup: lookupService,
+      interceptors: _interceptors,
+      codecRegistry: _codecRegistry,
       // ignore: unnecessary_cast
-      clientCertificate as io_bits.X509Certificate?,
-      _errorHandler,
+      clientCertificate: clientCertificate as io_bits.X509Certificate?,
+      errorHandler: _errorHandler,
     )..handle();
   }
 

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -87,7 +87,7 @@ class ConnectionServer {
   final Map<String, Service> _services = {};
   final List<Interceptor> _interceptors;
   final CodecRegistry? _codecRegistry;
-  final Function? _errorHandler;
+  final GrpcErrorHandler? _errorHandler;
 
   final _connections = <ServerTransportConnection>[];
 
@@ -96,7 +96,7 @@ class ConnectionServer {
     List<Service> services, [
     List<Interceptor> interceptors = const <Interceptor>[],
     CodecRegistry? codecRegistry,
-    Function? errorHandler,
+    GrpcErrorHandler? errorHandler,
   ])  : _codecRegistry = codecRegistry,
         _interceptors = interceptors,
         _errorHandler = errorHandler {
@@ -169,7 +169,7 @@ class Server extends ConnectionServer {
     required List<Service> services,
     List<Interceptor> interceptors = const <Interceptor>[],
     CodecRegistry? codecRegistry,
-    Function? errorHandler,
+    GrpcErrorHandler? errorHandler,
   }) : super(services, interceptors, codecRegistry, errorHandler);
 
   /// The port that the server is listening on, or `null` if the server is not

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -87,7 +87,7 @@ class ConnectionServer {
   final Map<String, Service> _services = {};
   final List<Interceptor> _interceptors;
   final CodecRegistry? _codecRegistry;
-  final Function? _responseErrorHandler;
+  final Function? _errorHandler;
 
   final _connections = <ServerTransportConnection>[];
 
@@ -96,10 +96,10 @@ class ConnectionServer {
     List<Service> services, [
     List<Interceptor> interceptors = const <Interceptor>[],
     CodecRegistry? codecRegistry,
-    Function? responseErrorHandler,
+    Function? errorHandler,
   ])  : _codecRegistry = codecRegistry,
         _interceptors = interceptors,
-        _responseErrorHandler = responseErrorHandler {
+        _errorHandler = errorHandler {
     for (final service in services) {
       _services[service.$name] = service;
     }
@@ -136,7 +136,7 @@ class ConnectionServer {
       lookupService, stream, _interceptors, _codecRegistry,
       // ignore: unnecessary_cast
       clientCertificate as io_bits.X509Certificate?,
-      _responseErrorHandler,
+      _errorHandler,
     )..handle();
   }
 }
@@ -154,7 +154,7 @@ class Server extends ConnectionServer {
     super.services, [
     super.interceptors,
     super.codecRegistry,
-    super.responseErrorHandler,
+    super.errorHandler,
   ]);
 
   /// Create a server for the given [services].
@@ -162,8 +162,8 @@ class Server extends ConnectionServer {
     required List<Service> services,
     List<Interceptor> interceptors = const <Interceptor>[],
     CodecRegistry? codecRegistry,
-    Function? responseErrorHandler,
-  }) : super(services, interceptors, codecRegistry, responseErrorHandler);
+    Function? errorHandler,
+  }) : super(services, interceptors, codecRegistry, errorHandler);
 
   /// The port that the server is listening on, or `null` if the server is not
   /// active.
@@ -246,7 +246,7 @@ class Server extends ConnectionServer {
       _codecRegistry,
       // ignore: unnecessary_cast
       clientCertificate as io_bits.X509Certificate?,
-      _responseErrorHandler,
+      _errorHandler,
     )..handle();
   }
 

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -149,12 +149,21 @@ class Server extends ConnectionServer {
   SecureServerSocket? _secureServer;
 
   /// Create a server for the given [services].
+  @Deprecated('use Server.create() instead')
   Server(
     super.services, [
     super.interceptors,
     super.codecRegistry,
     super.responseErrorHandler,
   ]);
+
+  /// Create a server for the given [services].
+  Server.create({
+    required List<Service> services,
+    List<Interceptor> interceptors = const <Interceptor>[],
+    CodecRegistry? codecRegistry,
+    Function? responseErrorHandler,
+  }) : super(services, interceptors, codecRegistry, responseErrorHandler);
 
   /// The port that the server is listening on, or `null` if the server is not
   /// active.

--- a/lib/src/server/server.dart
+++ b/lib/src/server/server.dart
@@ -87,6 +87,7 @@ class ConnectionServer {
   final Map<String, Service> _services = {};
   final List<Interceptor> _interceptors;
   final CodecRegistry? _codecRegistry;
+  final Function? _responseErrorHandler;
 
   final _connections = <ServerTransportConnection>[];
 
@@ -95,8 +96,10 @@ class ConnectionServer {
     List<Service> services, [
     List<Interceptor> interceptors = const <Interceptor>[],
     CodecRegistry? codecRegistry,
+    Function? responseErrorHandler,
   ])  : _codecRegistry = codecRegistry,
-        _interceptors = interceptors {
+        _interceptors = interceptors,
+        _responseErrorHandler = responseErrorHandler {
     for (final service in services) {
       _services[service.$name] = service;
     }
@@ -133,6 +136,7 @@ class ConnectionServer {
       lookupService, stream, _interceptors, _codecRegistry,
       // ignore: unnecessary_cast
       clientCertificate as io_bits.X509Certificate?,
+      _responseErrorHandler,
     )..handle();
   }
 }
@@ -232,6 +236,7 @@ class Server extends ConnectionServer {
       _codecRegistry,
       // ignore: unnecessary_cast
       clientCertificate as io_bits.X509Certificate?,
+      _responseErrorHandler,
     )..handle();
   }
 

--- a/test/client_certificate_test.dart
+++ b/test/client_certificate_test.dart
@@ -25,6 +25,7 @@ class EchoService extends EchoServiceBase {
 }
 
 const String address = 'localhost';
+
 Future<void> main() async {
   test('Client certificate required', () async {
     // Server
@@ -80,7 +81,7 @@ Future<void> main() async {
 }
 
 Future<Server> _setUpServer([bool requireClientCertificate = false]) async {
-  final server = Server([EchoService()]);
+  final server = Server.create(services: [EchoService()]);
   final serverContext = SecurityContextServerCredentials.baseSecurityContext();
   serverContext.useCertificateChain('test/data/localhost.crt');
   serverContext.usePrivateKey('test/data/localhost.key');
@@ -102,6 +103,7 @@ class SecurityContextChannelCredentials extends ChannelCredentials {
       {super.authority, super.onBadCertificate})
       : _securityContext = securityContext,
         super.secure();
+
   @override
   SecurityContext get securityContext => _securityContext;
 
@@ -116,8 +118,10 @@ class SecurityContextServerCredentials extends ServerTlsCredentials {
   SecurityContextServerCredentials(SecurityContext securityContext)
       : _securityContext = securityContext,
         super();
+
   @override
   SecurityContext get securityContext => _securityContext;
+
   static SecurityContext baseSecurityContext() {
     return createSecurityContext(true);
   }

--- a/test/client_handles_bad_connections_test.dart
+++ b/test/client_handles_bad_connections_test.dart
@@ -17,6 +17,7 @@ class TestClient extends grpc.Client {
       (List<int> value) => value[0]);
 
   TestClient(super.channel);
+
   grpc.ResponseStream<int> stream(int request, {grpc.CallOptions? options}) {
     return $createStreamingCall(_$stream, Stream.value(request),
         options: options);
@@ -42,11 +43,13 @@ class TestService extends grpc.Service {
 class FixedConnectionClientChannel extends ClientChannelBase {
   final Http2ClientConnection clientConnection;
   List<grpc.ConnectionState> states = <grpc.ConnectionState>[];
+
   FixedConnectionClientChannel(this.clientConnection) {
     onConnectionStateChanged.listen((state) {
       states.add(state);
     });
   }
+
   @override
   ClientConnection createConnection() => clientConnection;
 }
@@ -55,7 +58,7 @@ Future<void> main() async {
   testTcpAndUds('client reconnects after the connection gets old',
       (address) async {
     // client reconnect after a short delay.
-    final server = grpc.Server([TestService()]);
+    final server = grpc.Server.create(services: [TestService()]);
     await server.serve(address: address, port: 0);
 
     final channel = FixedConnectionClientChannel(Http2ClientConnection(
@@ -80,7 +83,7 @@ Future<void> main() async {
 
   testTcpAndUds('client reconnects when stream limit is used', (address) async {
     // client reconnect after setting stream limit.
-    final server = grpc.Server([TestService()]);
+    final server = grpc.Server.create(services: [TestService()]);
     await server.serve(
         address: address,
         port: 0,

--- a/test/grpc_web_server.dart
+++ b/test/grpc_web_server.dart
@@ -89,6 +89,7 @@ static_resources:
 // with an error. Otherwise if verbose is specified it will be dumped
 // to stdout unconditionally.
 final output = <String>[];
+
 void _info(String line) {
   if (!verbose) {
     output.add(line);
@@ -99,7 +100,7 @@ void _info(String line) {
 
 Future<void> hybridMain(StreamChannel channel) async {
   // Spawn a gRPC server.
-  final server = Server([EchoService()]);
+  final server = Server.create(services: [EchoService()]);
   await server.serve(port: 0);
   _info('grpc server listening on ${server.port}');
 

--- a/test/server_handles_broken_connection_test.dart
+++ b/test/server_handles_broken_connection_test.dart
@@ -2,8 +2,10 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';
+
 import 'package:grpc/grpc.dart' as grpc;
 import 'package:test/test.dart';
+
 import 'common.dart';
 
 class TestClient extends grpc.Client {
@@ -13,6 +15,7 @@ class TestClient extends grpc.Client {
       (List<int> value) => value[0]);
 
   TestClient(grpc.ClientChannel super.channel);
+
   grpc.ResponseStream<int> infiniteStream(int request,
       {grpc.CallOptions? options}) {
     return $createStreamingCall(_$infiniteStream, Stream.value(request),
@@ -52,6 +55,7 @@ class ClientData {
   final InternetAddress address;
   final int port;
   final SendPort sendPort;
+
   ClientData(
       {required this.address, required this.port, required this.sendPort});
 }
@@ -77,11 +81,12 @@ Future<void> main() async {
       (address) async {
     // interrrupt the connect of client, the server does not crash.
     late grpc.Server server;
-    server = grpc.Server([
+    server = grpc.Server.create(services: [
       TestService(
-          finallyCallback: expectAsync0(() {
-        expect(server.shutdown(), completes);
-      }, reason: 'the producer should get cancelled'))
+        finallyCallback: expectAsync0(() {
+          expect(server.shutdown(), completes);
+        }, reason: 'the producer should get cancelled'),
+      )
     ]);
     await server.serve(address: address, port: 0);
     final receivePort = ReceivePort();

--- a/test/src/server_utils.dart
+++ b/test/src/server_utils.dart
@@ -120,8 +120,10 @@ class TestServerStream extends ServerTransportStream {
 
 class ServerHarness extends _Harness {
   @override
-  ConnectionServer createServer() =>
-      Server(<Service>[service], <Interceptor>[interceptor]);
+  ConnectionServer createServer() => Server.create(
+        services: <Service>[service],
+        interceptors: <Interceptor>[interceptor],
+      );
 
   static ServiceMethod<int, int> createMethod(String name,
       Function methodHandler, bool clientStreaming, bool serverStreaming) {

--- a/test/timeline_test.dart
+++ b/test/timeline_test.dart
@@ -132,7 +132,7 @@ TimelineTask fakeTimelineTaskFactory(
     FakeTimelineTask(filterKey: filterKey, parent: parent);
 
 Future<void> testee() async {
-  final server = Server([TestService()]);
+  final server = Server.create(services: [TestService()]);
   await server.serve(address: 'localhost', port: 0);
   isTimelineLoggingEnabled = true;
   timelineTaskFactory = fakeTimelineTaskFactory;


### PR DESCRIPTION
This picks up where #520 left off and resolves #51.

My particular use case is needing to log (with stack traces) gRPC errors as they occur on the server, such as those having to do with deserialization.

cc: @mraleph 