### PR TITLE
Extend StreamView over DelegatingStream

### DIFF
--- a/lib/src/client/common.dart
+++ b/lib/src/client/common.dart
@@ -66,7 +66,7 @@ class ResponseFuture<R> extends DelegatingFuture<R>
 }
 
 /// A gRPC response producing a stream of values.
-class ResponseStream<R> extends DelegatingStream<R>
+class ResponseStream<R> extends StreamView<R>
     with _ResponseMixin<dynamic, R> {
   @override
   final ClientCall<dynamic, R> _call;

--- a/lib/src/client/common.dart
+++ b/lib/src/client/common.dart
@@ -66,8 +66,7 @@ class ResponseFuture<R> extends DelegatingFuture<R>
 }
 
 /// A gRPC response producing a stream of values.
-class ResponseStream<R> extends StreamView<R>
-    with _ResponseMixin<dynamic, R> {
+class ResponseStream<R> extends StreamView<R> with _ResponseMixin<dynamic, R> {
   @override
   final ClientCall<dynamic, R> _call;
 


### PR DESCRIPTION
The `StreamView` class from the SDK provides all the worthwhile behavior of `DelegatingStream` and the latter may soon be deprecated.