### PR TITLE
Add a ChannelShutdownHandler callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.1-dev
+## 3.2.0-dev
 
 * `ChannelOptions` now exposes `connectTimeout`, which is used on the 
   socket connect. This is used to specify the maximum allowed time to wait

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Require Dart 2.17 or greater.
 * Fix issue [#51](https://github.com/grpc/grpc-dart/issues/51), add support for custom error handling.
 * Expose client IP address to server 
+* Add a `channelShutdownHandler` argument to `ClientChannel` and the subclasses.
+  This callback can be used to react to channel shutdown or termination.
 
 ## 3.1.0
 

--- a/lib/grpc_connection_interface.dart
+++ b/lib/grpc_connection_interface.dart
@@ -17,7 +17,7 @@
 /// [ClientChannel].
 
 export 'src/client/call.dart' show CallOptions, ClientCall;
-export 'src/client/channel.dart' show ClientChannelBase, ChannelShutdownHandler;
+export 'src/client/channel.dart' show ClientChannelBase;
 export 'src/client/connection.dart' show ClientConnection;
 export 'src/client/http2_channel.dart' show ClientChannel;
 export 'src/client/options.dart' show ChannelOptions;

--- a/lib/grpc_connection_interface.dart
+++ b/lib/grpc_connection_interface.dart
@@ -17,7 +17,7 @@
 /// [ClientChannel].
 
 export 'src/client/call.dart' show CallOptions, ClientCall;
-export 'src/client/channel.dart' show ClientChannelBase;
+export 'src/client/channel.dart' show ClientChannelBase, ChannelShutdownHandler;
 export 'src/client/connection.dart' show ClientConnection;
 export 'src/client/http2_channel.dart' show ClientChannel;
 export 'src/client/options.dart' show ChannelOptions;

--- a/lib/src/client/channel.dart
+++ b/lib/src/client/channel.dart
@@ -22,6 +22,9 @@ import 'call.dart';
 import 'connection.dart';
 import 'method.dart';
 
+/// Handler to be called when the channel is shut down.
+typedef ChannelShutdownHandler = void Function();
+
 /// A channel to a virtual RPC endpoint.
 abstract class ClientChannel {
   /// Shuts down this channel.
@@ -55,8 +58,10 @@ abstract class ClientChannelBase implements ClientChannel {
   bool _isShutdown = false;
   final StreamController<ConnectionState> _connectionStateStreamController =
       StreamController.broadcast();
+  final ChannelShutdownHandler? _channelShutdownHandler;
 
-  ClientChannelBase();
+  ClientChannelBase({ChannelShutdownHandler? channelShutdownHandler})
+      : _channelShutdownHandler = channelShutdownHandler;
 
   @override
   Future<void> shutdown() async {
@@ -66,6 +71,7 @@ abstract class ClientChannelBase implements ClientChannel {
       await _connection.shutdown();
       await _connectionStateStreamController.close();
     }
+    _channelShutdownHandler?.call();
   }
 
   @override
@@ -75,6 +81,7 @@ abstract class ClientChannelBase implements ClientChannel {
       await _connection.terminate();
       await _connectionStateStreamController.close();
     }
+    _channelShutdownHandler?.call();
   }
 
   ClientConnection createConnection();

--- a/lib/src/client/channel.dart
+++ b/lib/src/client/channel.dart
@@ -22,9 +22,6 @@ import 'call.dart';
 import 'connection.dart';
 import 'method.dart';
 
-/// Handler to be called when the channel is shut down.
-typedef ChannelShutdownHandler = void Function();
-
 /// A channel to a virtual RPC endpoint.
 abstract class ClientChannel {
   /// Shuts down this channel.
@@ -58,9 +55,9 @@ abstract class ClientChannelBase implements ClientChannel {
   bool _isShutdown = false;
   final StreamController<ConnectionState> _connectionStateStreamController =
       StreamController.broadcast();
-  final ChannelShutdownHandler? _channelShutdownHandler;
+  final void Function()? _channelShutdownHandler;
 
-  ClientChannelBase({ChannelShutdownHandler? channelShutdownHandler})
+  ClientChannelBase({void Function()? channelShutdownHandler})
       : _channelShutdownHandler = channelShutdownHandler;
 
   @override

--- a/lib/src/client/http2_channel.dart
+++ b/lib/src/client/http2_channel.dart
@@ -37,7 +37,7 @@ class ClientChannel extends ClientChannelBase {
     this.port = 443,
     this.options = const ChannelOptions(),
     super.channelShutdownHandler,
-  }) : super();
+  });
 
   @override
   ClientConnection createConnection() =>

--- a/lib/src/client/http2_channel.dart
+++ b/lib/src/client/http2_channel.dart
@@ -32,9 +32,12 @@ class ClientChannel extends ClientChannelBase {
   final int port;
   final ChannelOptions options;
 
-  ClientChannel(this.host,
-      {this.port = 443, this.options = const ChannelOptions()})
-      : super();
+  ClientChannel(
+    this.host, {
+    this.port = 443,
+    this.options = const ChannelOptions(),
+    super.channelShutdownHandler,
+  }) : super();
 
   @override
   ClientConnection createConnection() =>

--- a/lib/src/client/web_channel.dart
+++ b/lib/src/client/web_channel.dart
@@ -21,7 +21,7 @@ import 'transport/xhr_transport.dart';
 class GrpcWebClientChannel extends ClientChannelBase {
   final Uri uri;
 
-  GrpcWebClientChannel.xhr(this.uri, {super.channelShutdownHandler}) : super();
+  GrpcWebClientChannel.xhr(this.uri, {super.channelShutdownHandler});
 
   @override
   ClientConnection createConnection() {

--- a/lib/src/client/web_channel.dart
+++ b/lib/src/client/web_channel.dart
@@ -21,7 +21,7 @@ import 'transport/xhr_transport.dart';
 class GrpcWebClientChannel extends ClientChannelBase {
   final Uri uri;
 
-  GrpcWebClientChannel.xhr(this.uri) : super();
+  GrpcWebClientChannel.xhr(this.uri, {super.channelShutdownHandler}) : super();
 
   @override
   ClientConnection createConnection() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: grpc
 description: Dart implementation of gRPC, a high performance, open-source universal RPC framework.
 
-version: 3.1.1-dev
+version: 3.2.0-dev
 
 repository: https://github.com/grpc/grpc-dart
 


### PR DESCRIPTION
Add a way to react to the channel shutdown or termination with an optional callback.

This is not necessarily the API which I would recommend, but this is the API that was already inappropriately shipped and in use internally.