### PR TITLE
Update Github CI workflows

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk: [3.0.0, dev]
+        sdk: [stable, dev]
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [3.0.0, dev]
+        sdk: [stable, dev]
         platform: [vm, chrome]
         exclude:
           # We only run Chrome tests on Linux. No need to run them

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [ master ]
   push:
-    tags: [ '[0-9]+.[0-9]+.[0-9]+' ]
+    tags: [ 'v[0-9]+.[0-9]+.[0-9]+' ]
 jobs:
   publish:
     uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main


### PR DESCRIPTION
- Switch test CI to `stable`.
- Switch tag format to `v3.2.0`, as the `publish` workflow doesn't support `3.2.0`.