### PR TITLE
Make ResponseStream a regular class

### DIFF
--- a/lib/src/client/common.dart
+++ b/lib/src/client/common.dart
@@ -66,8 +66,7 @@ class ResponseFuture<R> extends DelegatingFuture<R>
 }
 
 /// A gRPC response producing a stream of values.
-base class ResponseStream<R> extends StreamView<R>
-    with _ResponseMixin<dynamic, R> {
+class ResponseStream<R> extends StreamView<R> with _ResponseMixin<dynamic, R> {
   @override
   final ClientCall<dynamic, R> _call;
 


### PR DESCRIPTION
Reverts part of https://github.com/grpc/grpc-dart/commit/d9553ca73f66116f7ad14fff5d0e4814253311a4

Making `ResponseStream` a `base` class is not backward-compatible and makes it hard or impossible to work around https://github.com/grpc/grpc-dart/issues/413. 

Arguably, ResponseStream and ResponseFuture are serving two purposes: "The interface interceptors need to work with" and the base of implementations that have `ClientCall` state. A backwards-compatible future change could in principle separate an `interface` and a `base` class to decouple these.