### PR TITLE
Fix interop tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 3.2.3-wip
+## 3.2.3
 
 * Add const constructor to `GrpcError` fixing #606.
 * Make `GrpcError` non-final to allow implementations.
 * Only send keepalive pings on open connections.
+* Fix interop tests.
 
 ## 3.2.2
 

--- a/lib/grpc.dart
+++ b/lib/grpc.dart
@@ -21,6 +21,7 @@ export 'src/auth/auth_io.dart'
         ServiceAccountAuthenticator;
 export 'src/client/call.dart' show ClientCall;
 export 'src/client/client.dart' show Client;
+export 'src/client/client_keepalive.dart' show ClientKeepAliveOptions;
 export 'src/client/client_transport_connector.dart'
     show ClientTransportConnector;
 export 'src/client/connection.dart' show ConnectionState;
@@ -50,6 +51,7 @@ export 'src/server/server.dart'
         ServerTlsCredentials,
         ConnectionServer,
         Server;
+export 'src/server/server_keepalive.dart' show ServerKeepAliveOptions;
 export 'src/server/service.dart' show ServiceMethod, Service;
 export 'src/shared/api.dart';
 export 'src/shared/codec.dart' show Codec, IdentityCodec, GzipCodec;

--- a/lib/src/client/client_keepalive.dart
+++ b/lib/src/client/client_keepalive.dart
@@ -27,7 +27,7 @@ class ClientKeepAliveOptions {
 
   const ClientKeepAliveOptions({
     this.pingInterval,
-    this.timeout = const Duration(milliseconds: 20000),
+    this.timeout = const Duration(seconds: 20),
     this.permitWithoutCalls = false,
   });
 
@@ -189,7 +189,7 @@ class ClientKeepAlive {
   final void Function() ping;
 
   final ClientKeepAliveOptions _options;
-  Duration get _pingInterval => _options.pingInterval ?? Duration(days: 365);
+  Duration get _pingInterval => _options.pingInterval!;
 
   ClientKeepAlive({
     required ClientKeepAliveOptions options,
@@ -236,7 +236,9 @@ class ClientKeepAlive {
   }
 
   void _setState(KeepAliveEvent event) {
-    final newState = state.onEvent(event, this);
-    if (newState != null) state = newState;
+    if (_options.shouldSendPings) {
+      final newState = state.onEvent(event, this);
+      if (newState != null) state = newState;
+    }
   }
 }

--- a/lib/src/server/server_keepalive.dart
+++ b/lib/src/server/server_keepalive.dart
@@ -14,8 +14,7 @@ class ServerKeepAliveOptions {
   final Duration minIntervalBetweenPingsWithoutData;
 
   const ServerKeepAliveOptions({
-    this.minIntervalBetweenPingsWithoutData =
-        const Duration(milliseconds: 300000),
+    this.minIntervalBetweenPingsWithoutData = const Duration(minutes: 5),
     this.maxBadPings = 2,
   });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: grpc
 description: Dart implementation of gRPC, a high performance, open-source universal RPC framework.
-version: 3.2.3-wip
+version: 3.2.3
 
 repository: https://github.com/grpc/grpc-dart
 

--- a/test/keepalive_test.dart
+++ b/test/keepalive_test.dart
@@ -5,7 +5,6 @@ import 'package:grpc/grpc.dart';
 import 'package:grpc/src/client/client_keepalive.dart';
 import 'package:grpc/src/client/connection.dart';
 import 'package:grpc/src/client/http2_connection.dart';
-import 'package:grpc/src/server/server_keepalive.dart';
 import 'package:http2/transport.dart';
 import 'package:test/test.dart';
 

--- a/test/src/client_utils.dart
+++ b/test/src/client_utils.dart
@@ -18,7 +18,6 @@ import 'dart:convert';
 
 import 'package:grpc/grpc.dart';
 import 'package:grpc/src/client/channel.dart' as base;
-import 'package:grpc/src/client/client_keepalive.dart';
 import 'package:grpc/src/client/http2_connection.dart';
 import 'package:grpc/src/shared/message.dart';
 import 'package:http2/transport.dart';


### PR DESCRIPTION
- Fix interop tests by not canceling all handlers when a connection is done, but just the handlers of that connection.
- Some small cleanups of keepalive.