### PR TITLE
Allowing ErrorHandler to remove sensitive information.

### DIFF
--- a/lib/src/server/handler.dart
+++ b/lib/src/server/handler.dart
@@ -30,7 +30,7 @@ import 'interceptor.dart';
 import 'service.dart';
 
 typedef ServiceLookup = Service? Function(String service);
-typedef GrpcErrorHandler = void Function(GrpcError error, StackTrace? trace);
+typedef GrpcErrorHandler = GrpcError? Function(GrpcError error, StackTrace? trace);
 
 /// Handles an incoming gRPC call.
 class ServerHandler extends ServiceCall {
@@ -454,7 +454,7 @@ class ServerHandler extends ServiceCall {
   }
 
   void _sendError(GrpcError error, [StackTrace? trace]) {
-    _errorHandler?.call(error, trace);
+    error = _errorHandler?.call(error, trace) ?? error;
 
     sendTrailers(
       status: error.code,


### PR DESCRIPTION
Hey there dear team

I hope this is the right way to be doing this, if not, or if I missed out on important information, please let me know.

While developing a dart gRPC server for a client application I noticed that unhandled exceptions within a RPC cause a GrpcError of type INTERNAL to be returned to the client.

While I am aware, that the right path of action is to assure no unhandled Exceptions be thrown, eventually a bug will find it's way.

Receiving a message like `gRPC Error (code: 13, codeName: INTERNAL, message: Exception: SECRET_KEY not defined, details: [], rawResponse: null, trailers: {})` on client side raises two issues:

1. This could reveal sensitive information to an attacker
2. This doesn't reveal a lot of information when debugging

After looking through the code I've decided that using the existing infrastructure would probably be the fastest and most versatile approach. Therefore I propose expanding the existing errorHandler function definition by an optional return parameter of GrpcError and updating the call of the errorHandler within the _sendError function to override the initial error IF a new one is defined.

This allows for full backwards compatibility (As existing errorHandlers would not have a return value and therefore would not override the existing GrpcError), but also allows for more customisation through the handler.

A simple handler like `(error, trace) => error.code == 13 ? grpc.GrpcError.internal('Lorem Ipsum') : error // 13 => internal error` would allow to remove all sensitive information of an exception in a production environment and would instead return this GrpcError: `gRPC Error (code: 13, codeName: INTERNAL, message: Lorem Ipsum, details: [], rawResponse: null, trailers: {})`

While a Handler like: `(error, trace) => error.code == 13 ? grpc.GrpcError.internal(error.message, null, null, {'stack trace' : trace.toString()}) : error` allows for the stack trace to be added in dev environments and in turn a GrpcError like this one is returned to the client: `gRPC Error (code: 13, codeName: INTERNAL, message: Exception: SECRET_KEY not defined, details: [], rawResponse: null, trailers: {stack trace: 
#0      envGetOrThrow.<anonymous closure> (...)
#1      DotEnv.getOrElse (package:dotenv/src/dotenv.dart:52:43)
#2      ...`
(Although for this I had to manipulate files a little bit more, because the stack trace is only added to _sendError by about a third of calls thus far, but this is easily added thanks to the dart 3.0 addition of Records)

In my eyes the only downside of my approach is: The default is only as secure as the current solution and not more secretive.

TL;DR: slightly expanding the current functionalities of the errorHandler allows for greater customisability with increased security or increased debugability at no cost and full backwards compatibility.