### PR TITLE
Fix https://github.com/grpc/grpc-dart/issues/669

### DIFF
--- a/lib/src/shared/message.dart
+++ b/lib/src/shared/message.dart
@@ -68,7 +68,7 @@ List<int> frame(List<int> rawPayload, [Codec? codec]) {
   final payloadLength = compressedPayload.length;
   final bytes = Uint8List(payloadLength + 5);
   final header = bytes.buffer.asByteData(0, 5);
-  header.setUint8(0, codec == null ? 0 : 1);
+  header.setUint8(0, (codec == null|| codec.encodingName =="identity") ? 0 : 1);
   header.setUint32(1, payloadLength);
   bytes.setRange(5, bytes.length, compressedPayload);
   return bytes;


### PR DESCRIPTION
If message-encoding is set to identity, then compression flag should be 0.