### PR TITLE
Fix issue 669

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -19,7 +19,7 @@ jobs:
         sdk: [3.0.0, dev]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+      - uses: dart-lang/setup-dart@fedb1266e91cf51be2fdb382869461a434b920a3
         with:
           sdk: ${{ matrix.sdk }}
       - name: Report version
@@ -71,7 +71,7 @@ jobs:
             platform: chrome
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+      - uses: dart-lang/setup-dart@fedb1266e91cf51be2fdb382869461a434b920a3
         with:
           sdk: ${{ matrix.sdk }}
       - name: Report version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## latest master
+## 3.2.5
 
 * Set compressed flag correctly for grpc-encoding = identity. Fixes [#669](https://github.com/grpc/grpc-dart/issues/669) (https://github.com/grpc/grpc-dart/pull/693)
 

--- a/lib/src/shared/message.dart
+++ b/lib/src/shared/message.dart
@@ -68,7 +68,8 @@ List<int> frame(List<int> rawPayload, [Codec? codec]) {
   final payloadLength = compressedPayload.length;
   final bytes = Uint8List(payloadLength + 5);
   final header = bytes.buffer.asByteData(0, 5);
-  header.setUint8(0, (codec == null|| codec.encodingName =="identity") ? 0 : 1);
+  header.setUint8(
+      0, (codec == null || codec.encodingName == 'identity') ? 0 : 1);
   header.setUint32(1, payloadLength);
   bytes.setRange(5, bytes.length, compressedPayload);
   return bytes;

--- a/lib/src/shared/message.dart
+++ b/lib/src/shared/message.dart
@@ -68,7 +68,7 @@ List<int> frame(List<int> rawPayload, [Codec? codec]) {
   final payloadLength = compressedPayload.length;
   final bytes = Uint8List(payloadLength + 5);
   final header = bytes.buffer.asByteData(0, 5);
-  header.setUint8(0, codec == null ? 0 : 1);
+  header.setUint8(0, (codec == null|| codec.encodingName =="identity") ? 0 : 1);
   header.setUint32(1, payloadLength);
   bytes.setRange(5, bytes.length, compressedPayload);
   return bytes;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: grpc
 description: Dart implementation of gRPC, a high performance, open-source universal RPC framework.
-version: 3.2.4
+version: 3.2.5
 
 repository: https://github.com/grpc/grpc-dart
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dev_dependencies:
   test: ^1.16.0
   stream_channel: ^2.1.0
   stream_transform: ^2.0.0
-  vm_service: ">=11.6.0 <14.0.0"
+  vm_service: ">=11.6.0 <15.0.0"
   fake_async: ^1.3.1
 
 false_secrets:

--- a/test/grpc_compression_flag_test.dart
+++ b/test/grpc_compression_flag_test.dart
@@ -1,0 +1,27 @@
+import 'package:grpc/src/shared/message.dart';
+import 'package:grpc/src/shared/codec.dart';
+
+import 'package:test/test.dart';
+
+void main() {
+  group('GRPC Compression Flag', () {
+    test('compression flag 0 with null codec', () {
+      List<int> rawPayload = [1, 2, 3, 4];
+      Codec? codec = null;
+      final data = frame(rawPayload, codec);
+      expect(data[0], 0);
+    });
+    test('compression flag 0 with grpc-encoding identity', () {
+      List<int> rawPayload = [1, 2, 3, 4];
+      Codec? codec = IdentityCodec();
+      final data = frame(rawPayload, codec);
+      expect(data[0], 0);
+    });
+    test('compression flag 1 with grpc-encoding gzip', () {
+      List<int> rawPayload = [1, 2, 3, 4];
+      Codec? codec = GzipCodec();
+      final data = frame(rawPayload, codec);
+      expect(data[0], 1);
+    });
+  });
+}

--- a/test/grpc_compression_flag_test.dart
+++ b/test/grpc_compression_flag_test.dart
@@ -6,7 +6,7 @@ void main() {
   group('GRPC Compression Flag', () {
     test('compression flag 0 with null codec', () {
       final rawPayload = <int>[1, 2, 3, 4];
-      final Codec? codec;
+      final Codec? codec = null;
       final data = frame(rawPayload, codec);
       expect(data[0], 0);
     });

--- a/test/grpc_compression_flag_test.dart
+++ b/test/grpc_compression_flag_test.dart
@@ -1,25 +1,24 @@
-import 'package:grpc/src/shared/message.dart';
 import 'package:grpc/src/shared/codec.dart';
-
+import 'package:grpc/src/shared/message.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('GRPC Compression Flag', () {
     test('compression flag 0 with null codec', () {
-      List<int> rawPayload = [1, 2, 3, 4];
-      Codec? codec = null;
+      final rawPayload = <int>[1, 2, 3, 4];
+      final Codec? codec;
       final data = frame(rawPayload, codec);
       expect(data[0], 0);
     });
     test('compression flag 0 with grpc-encoding identity', () {
-      List<int> rawPayload = [1, 2, 3, 4];
-      Codec? codec = IdentityCodec();
+      final rawPayload = <int>[1, 2, 3, 4];
+      final Codec codec = IdentityCodec();
       final data = frame(rawPayload, codec);
       expect(data[0], 0);
     });
     test('compression flag 1 with grpc-encoding gzip', () {
-      List<int> rawPayload = [1, 2, 3, 4];
-      Codec? codec = GzipCodec();
+      final rawPayload = <int>[1, 2, 3, 4];
+      final Codec codec = GzipCodec();
       final data = frame(rawPayload, codec);
       expect(data[0], 1);
     });


### PR DESCRIPTION
https://grpc.github.io/grpc/core/md_doc_compression.html indicates that compression flag should not be set if grpc-encoding is identity.

This PR makes grpc-dart set the compression flag properly in this case.