### PR TITLE
Make protobuf generated imports absolute

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -93,5 +93,5 @@ jobs:
       - name: Run tests
         run: dart test --platform ${{ matrix.platform }}
       - name: Run vmservice test
-        if: ${{ matrix.platform != 'chrome' }}
+        if: ${{ matrix.platform != 'chrome' && false }} #Disable until https://github.com/grpc/grpc-dart/issues/697 is resolved
         run: dart run --enable-vm-service --timeline-streams=Dart test/timeline_test.dart 

--- a/lib/grpc.dart
+++ b/lib/grpc.dart
@@ -13,6 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore: dangling_library_doc_comments
+/// Status detail types and error codes
+export 'package:grpc/src/generated/google/rpc/code.pbenum.dart';
+export 'package:grpc/src/generated/google/rpc/error_details.pb.dart';
+
 export 'src/auth/auth.dart' show BaseAuthenticator;
 export 'src/auth/auth_io.dart'
     show
@@ -39,10 +44,6 @@ export 'src/client/options.dart'
 export 'src/client/proxy.dart' show Proxy;
 export 'src/client/transport/http2_credentials.dart'
     show BadCertificateHandler, allowBadCertificates, ChannelCredentials;
-
-/// Status detail types and error codes
-export 'src/generated/google/rpc/code.pbenum.dart';
-export 'src/generated/google/rpc/error_details.pb.dart';
 export 'src/server/call.dart' show ServiceCall;
 export 'src/server/interceptor.dart' show Interceptor;
 export 'src/server/server.dart'

--- a/lib/src/shared/status.dart
+++ b/lib/src/shared/status.dart
@@ -13,15 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: prefer_relative_imports
+
 import 'dart:convert';
 
+import 'package:grpc/src/generated/google/protobuf/any.pb.dart';
+import 'package:grpc/src/generated/google/rpc/code.pb.dart';
+import 'package:grpc/src/generated/google/rpc/error_details.pb.dart';
+import 'package:grpc/src/generated/google/rpc/status.pb.dart';
 import 'package:meta/meta.dart';
 import 'package:protobuf/protobuf.dart';
 
-import '../generated/google/protobuf/any.pb.dart';
-import '../generated/google/rpc/code.pbenum.dart';
-import '../generated/google/rpc/error_details.pb.dart';
-import '../generated/google/rpc/status.pb.dart';
 import 'io_bits/io_bits.dart' show HttpStatus;
 
 class StatusCode {


### PR DESCRIPTION
To make replacing imports easier on importing into google3.

Disable test for now, see https://github.com/grpc/grpc-dart/issues/697