### PR TITLE
Add `topics` to `pubspec.yaml`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,3 +33,8 @@ dev_dependencies:
 false_secrets:
  - interop/server1.key
  - test/data/localhost.key
+
+topics:
+ - grpc
+ - rpc
+ - protocols


### PR DESCRIPTION
Topics help users on pub.dev discover packages, and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to pubspec.yaml as follows:
```
topics:
 - my-topic
 - some-other-topic
```
See also: https://dart.dev/tools/pub/pubspec#topics