### PR TITLE
Fix hang that occurs when streaming calls are ongoing and a hot-restart occurs in Flutter web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Remove generated status codes.
 * Remove dependency on `package:archive`.
 * Move `codec.dart`.
+* Work around hang during Flutter hot restart by adding default case handler in _GrpcWebConversionSink.add.
 
 ## 3.2.4
 


### PR DESCRIPTION
When hot-restarting in Flutter Web, streaming GRPC calls can get stuck in this [method](https://github.com/grpc/grpc-dart/blob/dee1b2b43b5059ac625cf915ac062dc13ab0f274/lib/src/client/transport/web_streams.dart#L132) of `_GrpcWebConversionSink`:

```
  @override
  void add(ByteBuffer chunk) {
    _chunkOffset = 0;
    final chunkData = chunk.asUint8List();
    while (_chunkOffset < chunk.lengthInBytes) {
      switch (_state) {
        case _GrpcWebParseState.init:
          _frameType = _parseFrameType(chunkData);
          break;
        case _GrpcWebParseState.length:
          _parseLength(chunkData);
          break;
        case _GrpcWebParseState.message:
          _parseMessage(chunkData);
          break;
      }
    }
    _chunkOffset = 0;
  }
```

The `while` loop runs, but the `switch` statement doesn't match any cases so it just keeps looping. This seems to have something to with some issues around how Dart handles enums across isolates (some discussion [here ](https://github.com/dart-lang/sdk/issues/35626)and elsewhere) and the fact that hot-restarting involves the creation of a new isolate. 

In any case, adding a `default` handler causes the loop to break when a call is orphaned in this manner, which lets the isolate shut down and the hot-restart succeed.

There is also some discussion in the Dart/Flutter community about creating hooks for all platforms that would allow one to reliably detect when an isolate were shutting down and take action. If that were in place, that would allow for a cleaner solution, but it doesn't seem to be available yet.