### PR TITLE
fix: keep alive timeout finishes transport instead of connection shutdown

### DIFF
--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -113,7 +113,7 @@ class Http2ClientConnection implements connection.ClientConnection {
               transport.ping();
             }
           },
-          onPingTimeout: () => shutdown(),
+          onPingTimeout: () => transport.finish(),
         );
         transport.onFrameReceived
             .listen((_) => keepAliveManager?.onFrameReceived());


### PR DESCRIPTION
Currently, when the keep alive manager runs into a timeout, the connection is shutdown. The channel, however, cannot recover and stays in a stuck state.

Instead, we should finish the transport, which eventually will change the connection to be in transient failure mode, from where it recovers, once a stable connection can be established again.