### PR TITLE
Use `Map.of` instead of `Map.from` in grpc client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.2
+
+* Internal optimization to client code.
+
 ## 4.0.1
 
 * Fix header and trailing not completing if the call is terminated. Fixes [#727](https://github.com/grpc/grpc-dart/issues/727)
@@ -31,19 +35,19 @@
 
 ## 3.2.1
 
-* `package:http` now supports more versions: `>=0.13.0 <2.0.0`. 
+* `package:http` now supports more versions: `>=0.13.0 <2.0.0`.
 * `package:protobuf` new supports more versions: `>=2.0.0 <4.0.0`.
 
 ## 3.2.0
 
-* `ChannelOptions` now exposes `connectTimeout`, which is used on the 
+* `ChannelOptions` now exposes `connectTimeout`, which is used on the
   socket connect. This is used to specify the maximum allowed time to wait
   for a connection to be established. If `connectTime` is longer than the system
   level timeout duration, a timeout may occur sooner than specified in
   `connectTimeout`. On timeout, a `SocketException` is thrown.
 * Require Dart 2.17 or greater.
 * Fix issue [#51](https://github.com/grpc/grpc-dart/issues/51), add support for custom error handling.
-* Expose client IP address to server 
+* Expose client IP address to server
 * Add a `channelShutdownHandler` argument to `ClientChannel` and the subclasses.
   This callback can be used to react to channel shutdown or termination.
 * Export the `Code` protobuf enum from the `grpc.dart` library.

--- a/lib/src/client/call.dart
+++ b/lib/src/client/call.dart
@@ -86,9 +86,9 @@ class CallOptions {
 
   CallOptions mergedWith(CallOptions? other) {
     if (other == null) return this;
-    final mergedMetadata = Map.from(metadata)..addAll(other.metadata);
+    final mergedMetadata = Map.of(metadata)..addAll(other.metadata);
     final mergedTimeout = other.timeout ?? timeout;
-    final mergedProviders = List.from(metadataProviders)
+    final mergedProviders = List.of(metadataProviders)
       ..addAll(other.metadataProviders);
     final mergedCompression = other.compression ?? compression;
     return CallOptions._(
@@ -146,9 +146,9 @@ class WebCallOptions extends CallOptions {
   CallOptions mergedWith(CallOptions? other) {
     if (other == null) return this;
 
-    final mergedMetadata = Map.from(metadata)..addAll(other.metadata);
+    final mergedMetadata = Map.of(metadata)..addAll(other.metadata);
     final mergedTimeout = other.timeout ?? timeout;
-    final mergedProviders = List.from(metadataProviders)
+    final mergedProviders = List.of(metadataProviders)
       ..addAll(other.metadataProviders);
 
     if (other is! WebCallOptions) {
@@ -241,7 +241,7 @@ class ClientCall<Q, R> implements Response {
     if (options.metadataProviders.isEmpty) {
       _sendRequest(connection, _sanitizeMetadata(options.metadata));
     } else {
-      final metadata = Map<String, String>.from(options.metadata);
+      final metadata = Map<String, String>.of(options.metadata);
       Future.forEach(
               options.metadataProviders,
               (MetadataProvider provider) => provider(metadata,

--- a/lib/src/shared/status.dart
+++ b/lib/src/shared/status.dart
@@ -473,7 +473,7 @@ GrpcError? grpcErrorDetailsFromTrailers(Map<String, String> trailers) {
 }
 
 Map<String, String> toCustomTrailers(Map<String, String> trailers) {
-  return Map.from(trailers)
+  return Map.of(trailers)
     ..remove(':status')
     ..remove('content-type')
     ..remove('grpc-status')

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: grpc
 description: Dart implementation of gRPC, a high performance, open-source universal RPC framework.
-version: 4.0.1
+version: 4.0.2
 
 repository: https://github.com/grpc/grpc-dart
 


### PR DESCRIPTION
`Map.of` creates a new map with the same keys, values and *type* as the original map,
when used without type arguments or context type, where `Map.from` creates a `Map<dynamic, dynamic>`.
(This code failed on an attempt to make `Map.unmodifiable` be more strictly typed,
like `Map.of` instead of `Map.from`, showing that an intermediate map had type
`Map<dynamic, dynamic>` unnecessarily).

Same for using `List.of` instead of `List.from`.

The new code should be (microscopically) more efficient and type safe, and is forwards-compatible
with a stronger type on `Map.unmodifiable`.

(The code can be optimized more. For example
`List.of(list1)..addAll(list2)` can be just `list1 + list2` or `[...list1, ...list2]`,
both of which may know the total number of elements when doing the
initial list allocation. This is a minimal change to allow the type changes
for `.unmodifiable` to get past this very initial blocker in internal tests.)