### PR TITLE
fix: fix headers not completing when call is terminated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.1
+
+* Fix header and trailing not completing if the call is terminated. Fixes [#727](https://github.com/grpc/grpc-dart/issues/727)
+
 ## 4.0.0
 
 * Set compressed flag correctly for grpc-encoding = identity. Fixes [#669](https://github.com/grpc/grpc-dart/issues/669) (https://github.com/grpc/grpc-dart/pull/693)

--- a/lib/src/client/call.dart
+++ b/lib/src/client/call.dart
@@ -484,12 +484,10 @@ class ClientCall<Q, R> implements Response {
       futures.add(_responseSubscription!.cancel());
     }
     if (!_headers.isCompleted) {
-      _headers.completeError(
-          GrpcError.unimplemented('Request terminated before headers'));
+      _headers.complete({});
     }
     if (!_trailers.isCompleted) {
-      _trailers.completeError(
-          GrpcError.unimplemented('Request terminated before trailers'));
+      _trailers.complete({});
     }
     await Future.wait(futures);
   }

--- a/lib/src/client/call.dart
+++ b/lib/src/client/call.dart
@@ -485,11 +485,11 @@ class ClientCall<Q, R> implements Response {
     }
     if (!_headers.isCompleted) {
       _headers.completeError(
-          GrpcError.unimplemented("Request terminated before headers"));
+          GrpcError.unimplemented('Request terminated before headers'));
     }
     if (!_trailers.isCompleted) {
       _trailers.completeError(
-          GrpcError.unimplemented("Request terminated before trailers"));
+          GrpcError.unimplemented('Request terminated before trailers'));
     }
     await Future.wait(futures);
   }

--- a/lib/src/client/call.dart
+++ b/lib/src/client/call.dart
@@ -483,6 +483,14 @@ class ClientCall<Q, R> implements Response {
     if (_responseSubscription != null) {
       futures.add(_responseSubscription!.cancel());
     }
+    if (!_headers.isCompleted) {
+      _headers.completeError(
+          GrpcError.unimplemented("Request terminated before headers"));
+    }
+    if (!_trailers.isCompleted) {
+      _trailers.completeError(
+          GrpcError.unimplemented("Request terminated before trailers"));
+    }
     await Future.wait(futures);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: grpc
 description: Dart implementation of gRPC, a high performance, open-source universal RPC framework.
-version: 4.0.0
+version: 4.0.1
 
 repository: https://github.com/grpc/grpc-dart
 

--- a/test/client_tests/call_test.dart
+++ b/test/client_tests/call_test.dart
@@ -13,10 +13,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:grpc/grpc.dart';
 import 'package:grpc/src/client/call.dart';
 import 'package:test/test.dart';
 
+import '../src/client_utils.dart';
+
 void main() {
+  const dummyValue = 0;
+  const cancelDurationMillis = 300;
+
+  late ClientHarness harness;
+
+  setUp(() {
+    harness = ClientHarness()..setUp();
+  });
+
+  tearDown(() {
+    harness.tearDown();
+  });
+
   test('WebCallOptions mergeWith CallOptions returns WebCallOptions', () {
     final options =
         WebCallOptions(bypassCorsPreflight: true, withCredentials: true);
@@ -28,4 +44,55 @@ void main() {
     expect(mergedOptions.bypassCorsPreflight, true);
     expect(mergedOptions.withCredentials, true);
   });
+
+  test(
+    'Terminating a call correctly complete headers and trailers futures',
+    () async {
+      final clientCall = harness.client.unary(dummyValue);
+      clientCall.catchError((error) {
+        expect(error.codeName, equals('CANCELLED'));
+        return dummyValue;
+      });
+
+      Future.delayed(
+        Duration(milliseconds: cancelDurationMillis),
+      ).then((_) {
+        clientCall.cancel();
+      });
+
+      await expectLater(
+        clientCall.headers,
+        throwsA(
+          isA<GrpcError>()
+              .having(
+                (e) => e.codeName,
+                'Test codename',
+                contains('UNIMPLEMENTED'),
+              )
+              .having(
+                (e) => e.message,
+                'Test message',
+                contains('headers'),
+              ),
+        ),
+      );
+      await expectLater(
+        clientCall.trailers,
+        throwsA(
+          isA<GrpcError>()
+              .having(
+                (e) => e.codeName,
+                'Test codename',
+                contains('UNIMPLEMENTED'),
+              )
+              .having(
+                (e) => e.message,
+                'Test message',
+                contains('trailers'),
+              ),
+        ),
+      );
+    },
+    timeout: Timeout(Duration(milliseconds: cancelDurationMillis * 2)),
+  );
 }

--- a/test/keepalive_test.dart
+++ b/test/keepalive_test.dart
@@ -49,7 +49,7 @@ void main() {
       services: [FakeEchoService()],
       keepAliveOptions: serverOptions,
     );
-    await server.serve(address: 'localhost', port: 8082);
+    await server.serve(address: 'localhost', port: 0);
     fakeChannel = FakeClientChannel(
       'localhost',
       port: server.port!,

--- a/test/keepalive_test.dart
+++ b/test/keepalive_test.dart
@@ -49,7 +49,7 @@ void main() {
       services: [FakeEchoService()],
       keepAliveOptions: serverOptions,
     );
-    await server.serve(address: 'localhost', port: 8081);
+    await server.serve(address: 'localhost', port: 8082);
     fakeChannel = FakeClientChannel(
       'localhost',
       port: server.port!,


### PR DESCRIPTION
This PR attempt to solve the issue with headers not being correctly completed after a call is closed as pointed out in https://github.com/grpc/grpc-dart/issues/727

To fix the issue I have added in the `_terminate()` method a check to complete with errors any completer still going (I found `_headers` and `_trailers`)