### PR TITLE
update: Migrate off legacy JS/HTML apis

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk: [3.2.0, dev]
+        sdk: [3.4.0, dev]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [3.2.0, dev]
+        sdk: [3.4.0, dev]
         platform: [vm, chrome]
         exclude:
           # We only run Chrome tests on Linux. No need to run them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
+## 4.0.2-wip
+
+* Internal optimization to client code.
+* Small fixes, such as ports in testing and enabling `timeline_test.dart`.
+* When the keep alive manager runs into a timeout, it will finish the transport instead of closing
+  the connection, as defined in the gRPC spec.
+* Update xhr transport to migrate off legacy JS/HTML apis.
+
 ## 4.0.1
 
-* Update xhr transport to migrate off legacy JS/HTML apis.
+* Fix header and trailing not completing if the call is terminated. Fixes [#727](https://github.com/grpc/grpc-dart/issues/727)
 
 ## 4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.1
+
+* Update xhr transport to migrate off legacy JS/HTML apis.
+
 ## 4.0.0
 
 * Set compressed flag correctly for grpc-encoding = identity. Fixes [#669](https://github.com/grpc/grpc-dart/issues/669) (https://github.com/grpc/grpc-dart/pull/693)

--- a/lib/grpc_or_grpcweb.dart
+++ b/lib/grpc_or_grpcweb.dart
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'src/client/grpc_or_grpcweb_channel_grpc.dart'
-    if (dart.library.html) 'src/client/grpc_or_grpcweb_channel_web.dart';
+import 'src/client/grpc_or_grpcweb_channel_web.dart'
+    if (dart.library.io) 'src/client/grpc_or_grpcweb_channel_grpc.dart';
 import 'src/client/http2_channel.dart';
 import 'src/client/options.dart';
 

--- a/lib/grpc_or_grpcweb.dart
+++ b/lib/grpc_or_grpcweb.dart
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'src/client/grpc_or_grpcweb_channel_web.dart'
-    if (dart.library.io) 'src/client/grpc_or_grpcweb_channel_grpc.dart';
+import 'src/client/grpc_or_grpcweb_channel_grpc.dart'
+    if (dart.library.js_interop) 'src/client/grpc_or_grpcweb_channel_web.dart';
 import 'src/client/http2_channel.dart';
 import 'src/client/options.dart';
 

--- a/lib/src/client/transport/xhr_transport.dart
+++ b/lib/src/client/transport/xhr_transport.dart
@@ -59,14 +59,12 @@ class XhrTransportStream implements GrpcTransportStream {
       if (_incomingProcessor.isClosed) {
         return;
       }
-      switch (_request.readyState) {
-        case 2:
-          _onHeadersReceived();
-          break;
-        case 4:
-          _onRequestDone();
-          _close();
-          break;
+      // TODO: dart-lang/web#285 use 'if' for now
+      if (_request.readyState == XMLHttpRequest.HEADERS_RECEIVED) {
+        _onHeadersReceived();
+      } else if (_request.readyState == XMLHttpRequest.DONE) {
+        _onRequestDone();
+        _close();
       }
     });
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   http2: ^2.2.0
   protobuf: '>=2.0.0 <4.0.0'
   clock: ^1.1.1
+  web: ^1.0.0
 
 dev_dependencies:
   build_runner: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   http2: ^2.2.0
   protobuf: '>=2.0.0 <4.0.0'
   clock: ^1.1.1
-  web: ^1.0.0
+  web: ^1.1.0
 
 dev_dependencies:
   build_runner: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: grpc
 description: Dart implementation of gRPC, a high performance, open-source universal RPC framework.
-version: 4.0.0
+version: 4.0.1
 
 repository: https://github.com/grpc/grpc-dart
 
 environment:
-  sdk: ^3.2.0
+  sdk: ^3.4.0
 
 dependencies:
   async: ^2.5.0


### PR DESCRIPTION
The purpose of this PR is to fix the issue mentioned in #715, I have test both unary/server side stream requests on canvaskit/wasm platform.Thanks to @hyunw55 `s comment in https://github.com/grpc/grpc-dart/issues/715#issuecomment-2133525797.

Main updates include:

1. add web v1.0.0 package and `XMLHttpRequest` to replace html package.
2. use `dart.library.io` to determine the current platform.