### PR TITLE
Small fixes

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -93,5 +93,5 @@ jobs:
       - name: Run tests
         run: dart test --platform ${{ matrix.platform }}
       - name: Run vmservice test
-        if: ${{ matrix.platform != 'chrome' && false }} #Disable until https://github.com/grpc/grpc-dart/issues/697 is resolved
+        if: ${{ matrix.platform != 'chrome' }}
         run: dart run --enable-vm-service --timeline-streams=Dart test/timeline_test.dart 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.2-wip
+
+* Small fixes, such as ports in testing and enabling `timeline_test.dart`.
+
 ## 4.0.1
 
 * Fix header and trailing not completing if the call is terminated. Fixes [#727](https://github.com/grpc/grpc-dart/issues/727)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The [Dart](https://www.dart.dev/) implementation of
 ## Learn more
 
 - [Quick Start](https://grpc.io/docs/languages/dart/quickstart) - get an app running in minutes
-- [Examples](example)
+- [Examples](https://github.com/grpc/grpc-dart/tree/master/example)
 - [API reference](https://grpc.io/docs/languages/dart/api)
 
 For complete documentation, see [Dart gRPC](https://grpc.io/docs/languages/dart).

--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -113,7 +113,7 @@ class Http2ClientConnection implements connection.ClientConnection {
               transport.ping();
             }
           },
-          onPingTimeout: () => shutdown(),
+          onPingTimeout: () => transport.finish(),
         );
         transport.onFrameReceived
             .listen((_) => keepAliveManager?.onFrameReceived());

--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -113,7 +113,7 @@ class Http2ClientConnection implements connection.ClientConnection {
               transport.ping();
             }
           },
-          onPingTimeout: () => transport.finish(),
+          onPingTimeout: () => shutdown(),
         );
         transport.onFrameReceived
             .listen((_) => keepAliveManager?.onFrameReceived());

--- a/lib/src/shared/status.dart
+++ b/lib/src/shared/status.dart
@@ -352,6 +352,7 @@ class GrpcError implements Exception {
 /// This list comes from `error_details.proto`. If any new error detail types are
 /// added to the protbuf definition, this function should be updated accordingly to
 /// support them.
+@visibleForTesting
 GeneratedMessage parseErrorDetailsFromAny(Any any) {
   switch (any.typeUrl) {
     case 'type.googleapis.com/google.rpc.RetryInfo':

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: grpc
 description: Dart implementation of gRPC, a high performance, open-source universal RPC framework.
-version: 4.0.1
+version: 4.0.2-wip
 
 repository: https://github.com/grpc/grpc-dart
 

--- a/test/client_tests/client_xhr_transport_test.dart
+++ b/test/client_tests/client_xhr_transport_test.dart
@@ -65,7 +65,7 @@ class MockHttpRequest extends Mock implements HttpRequest {
 class MockXhrClientConnection extends XhrClientConnection {
   MockXhrClientConnection({int? code})
       : _statusCode = code ?? 200,
-        super(Uri.parse('test:8080'));
+        super(Uri.parse('test:0'));
 
   late MockHttpRequest latestRequest;
   final int _statusCode;

--- a/test/client_tests/grpc_or_grpcweb_channel_grpc_test.dart
+++ b/test/client_tests/grpc_or_grpcweb_channel_grpc_test.dart
@@ -20,7 +20,7 @@ import 'package:grpc/grpc_or_grpcweb.dart';
 import 'package:test/test.dart';
 
 const host = 'example.com';
-const port = 8080;
+const port = 0;
 
 void main() {
   test('Channel on non-web uses gRPC ClientChannel with correct params', () {

--- a/test/client_tests/grpc_or_grpcweb_channel_web_test.dart
+++ b/test/client_tests/grpc_or_grpcweb_channel_web_test.dart
@@ -20,7 +20,7 @@ import 'package:grpc/grpc_web.dart';
 import 'package:test/test.dart';
 
 const host = 'example.com';
-const port = 8080;
+const port = 0;
 
 void main() {
   test('Channel on web uses GrpcWebClientChannel with correct URI', () {

--- a/test/keepalive_test.dart
+++ b/test/keepalive_test.dart
@@ -98,6 +98,9 @@ void main() {
     );
     await Future.delayed(timeout * 2, () => timer.cancel());
 
+    // Wait for last request to be sent
+    await Future.delayed(timeout);
+
     // Check that the server never closed the connection
     expect(fakeChannel.newConnectionCounter, 1);
   });

--- a/test/keepalive_test.dart
+++ b/test/keepalive_test.dart
@@ -92,17 +92,23 @@ void main() {
 
   test('Server doesnt terminate connection after pings, as data is sent',
       () async {
-    final timer = Timer.periodic(
-      pingInterval,
-      (_) => fakeClient.echo(EchoRequest()),
-    );
-    await Future.delayed(timeout * 2, () => timer.cancel());
+    try {
+      //DONOTSUBMIT
+      final timer = Timer.periodic(
+        pingInterval,
+        (_) => fakeClient.echo(EchoRequest()),
+      );
+      await Future.delayed(timeout * 2, () => timer.cancel());
 
-    // Wait fro some time for the requests to be sent and processed
-    await Future.delayed(timeout);
+      // Wait fro some time for the requests to be sent and processed
+      await Future.delayed(timeout);
 
-    // Check that the server never closed the connection
-    expect(fakeChannel.newConnectionCounter, 1);
+      // Check that the server never closed the connection
+      expect(fakeChannel.newConnectionCounter, 1);
+    } catch (e, s) {
+      print(e);
+      print(s);
+    }
   });
 
   test('Server doesnt ack the ping, making the client shutdown the connection',

--- a/test/keepalive_test.dart
+++ b/test/keepalive_test.dart
@@ -92,24 +92,13 @@ void main() {
 
   test('Server doesnt terminate connection after pings, as data is sent',
       () async {
-    try {
-      //DONOTSUBMIT
-      final timer = Timer.periodic(
-        pingInterval,
-        (_) => fakeClient.echo(EchoRequest()),
-      );
-      await Future.delayed(timeout * 2, () => timer.cancel());
-
-      // Wait fro some time for the requests to be sent and processed
-      await Future.delayed(timeout);
-
-      // Check that the server never closed the connection
-      expect(fakeChannel.newConnectionCounter, 1);
-    } catch (e, s) {
-      print(e);
-      print(s);
-      fail('Stacktrace: $s');
+    for (var i = 0; i < 10; i++) {
+      await fakeClient.echo(EchoRequest());
+      await Future.delayed(timeout * 0.2);
     }
+
+    // Check that the server never closed the connection
+    expect(fakeChannel.newConnectionCounter, 1);
   });
 
   test('Server doesnt ack the ping, making the client shutdown the connection',

--- a/test/keepalive_test.dart
+++ b/test/keepalive_test.dart
@@ -108,7 +108,7 @@ void main() {
     } catch (e, s) {
       print(e);
       print(s);
-      rethrow;
+      fail('Stacktrace: $s');
     }
   });
 

--- a/test/keepalive_test.dart
+++ b/test/keepalive_test.dart
@@ -34,14 +34,18 @@ void main() {
   late EchoServiceClient unresponsiveClient;
   late ClientChannel unresponsiveChannel;
 
+  final pingInterval = Duration(milliseconds: 10);
+  final timeout = Duration(milliseconds: 30);
+  final maxBadPings = 5;
+
   setUp(() async {
     final serverOptions = ServerKeepAliveOptions(
-      maxBadPings: 5,
+      maxBadPings: maxBadPings,
       minIntervalBetweenPingsWithoutData: Duration(milliseconds: 10),
     );
     final clientOptions = ClientKeepAliveOptions(
-      pingInterval: Duration(milliseconds: 10),
-      timeout: Duration(milliseconds: 30),
+      pingInterval: pingInterval,
+      timeout: timeout,
       permitWithoutCalls: true,
     );
 
@@ -79,7 +83,7 @@ void main() {
   test('Server terminates connection after too many pings without data',
       () async {
     await fakeClient.echo(EchoRequest());
-    await Future.delayed(Duration(milliseconds: 300));
+    await Future.delayed(timeout * maxBadPings * 2);
     await fakeClient.echo(EchoRequest());
     // Check that the server closed the connection, the next request then has
     // to build a new one.
@@ -89,11 +93,10 @@ void main() {
   test('Server doesnt terminate connection after pings, as data is sent',
       () async {
     final timer = Timer.periodic(
-        Duration(milliseconds: 10), (timer) => fakeClient.echo(EchoRequest()));
-    await Future.delayed(Duration(milliseconds: 200), () => timer.cancel());
-
-    // Wait for last request to be sent
-    await Future.delayed(Duration(milliseconds: 20));
+      pingInterval,
+      (_) => fakeClient.echo(EchoRequest()),
+    );
+    await Future.delayed(timeout * 2, () => timer.cancel());
 
     // Check that the server never closed the connection
     expect(fakeChannel.newConnectionCounter, 1);
@@ -102,9 +105,11 @@ void main() {
   test('Server doesnt ack the ping, making the client shutdown the connection',
       () async {
     await unresponsiveClient.echo(EchoRequest());
-    await Future.delayed(Duration(milliseconds: 200));
+    await Future.delayed(timeout * 2);
     await expectLater(
-        unresponsiveClient.echo(EchoRequest()), throwsA(isA<GrpcError>()));
+      unresponsiveClient.echo(EchoRequest()),
+      throwsA(isA<GrpcError>()),
+    );
   });
 }
 
@@ -113,7 +118,7 @@ class FakeClientChannel extends ClientChannel {
   FakeHttp2ClientConnection? fakeHttp2ClientConnection;
   FakeClientChannel(
     super.host, {
-    super.port = 443,
+    super.port,
     super.options = const ChannelOptions(),
     super.channelShutdownHandler,
   });
@@ -145,7 +150,7 @@ class FakeHttp2ClientConnection extends Http2ClientConnection {
 class UnresponsiveClientChannel extends ClientChannel {
   UnresponsiveClientChannel(
     super.host, {
-    super.port = 443,
+    super.port,
     super.options = const ChannelOptions(),
     super.channelShutdownHandler,
   });
@@ -189,8 +194,6 @@ class FakeEchoService extends EchoServiceBase {
 
   @override
   Stream<ServerStreamingEchoResponse> serverStreamingEcho(
-      ServiceCall call, ServerStreamingEchoRequest request) {
-    // TODO: implement serverStreamingEcho
-    throw UnimplementedError();
-  }
+          ServiceCall call, ServerStreamingEchoRequest request) =>
+      throw UnsupportedError('Not used in this test');
 }

--- a/test/keepalive_test.dart
+++ b/test/keepalive_test.dart
@@ -98,7 +98,7 @@ void main() {
     );
     await Future.delayed(timeout * 2, () => timer.cancel());
 
-    // Wait for last request to be sent
+    // Wait fro some time for the requests to be sent and processed
     await Future.delayed(timeout);
 
     // Check that the server never closed the connection

--- a/test/keepalive_test.dart
+++ b/test/keepalive_test.dart
@@ -108,6 +108,7 @@ void main() {
     } catch (e, s) {
       print(e);
       print(s);
+      rethrow;
     }
   });
 

--- a/test/proxy_secure_test.dart
+++ b/test/proxy_secure_test.dart
@@ -33,13 +33,13 @@ void main() {
     server = Server.create(services: [FakeEchoService()]);
     await server.serve(
       address: 'localhost',
-      port: 8888,
+      port: 0,
       security: ServerTlsCredentials(
         certificate: File('test/data/localhost.crt').readAsBytesSync(),
         privateKey: File('test/data/localhost.key').readAsBytesSync(),
       ),
     );
-    final proxy = Proxy(host: 'localhost', port: 8080);
+    final proxy = Proxy(host: 'localhost', port: 0);
     final proxyCAName = '/CN=mitmproxy/O=mitmproxy';
 
     fakeChannel = ClientChannel(

--- a/test/proxy_test.dart
+++ b/test/proxy_test.dart
@@ -30,9 +30,9 @@ void main() {
 
   setUp(() async {
     server = Server.create(services: [FakeEchoService()]);
-    await server.serve(address: 'localhost', port: 8888);
+    await server.serve(address: 'localhost', port: 0);
 
-    final proxy = Proxy(host: 'localhost', port: 8080);
+    final proxy = Proxy(host: 'localhost', port: 0);
 
     fakeChannel = ClientChannel(
       'localhost',

--- a/test/server_cancellation_test.dart
+++ b/test/server_cancellation_test.dart
@@ -47,7 +47,7 @@ void main() {
     server = Server.create(
       services: [EchoService()],
     );
-    await server.serve(address: 'localhost', port: 8081);
+    await server.serve(address: 'localhost', port: 0);
     channel = ClientChannel(
       'localhost',
       port: server.port!,

--- a/test/tools/http2_client.dart
+++ b/test/tools/http2_client.dart
@@ -20,7 +20,7 @@ import 'package:grpc/src/client/http2_connection.dart';
 import 'package:http2/http2.dart';
 
 Future<void> main(List<String> args) async {
-  final serverPort = 5678;
+  final serverPort = 0;
   final proxyPort = int.tryParse(args.first);
 
   final proxy =
@@ -37,7 +37,7 @@ Future<void> main(List<String> args) async {
   final incoming =
       proxy == null ? connector.socket : await connector.connectToProxy(proxy);
 
-  final uri = Uri.parse('http://localhost:8080');
+  final uri = Uri.parse('http://localhost:0');
 
   final transport =
       ClientTransportConnection.viaStreams(incoming, connector.socket);


### PR DESCRIPTION
I also looked into the leaking API symbols: 
 - `ServerHandler` is only visible for testing (the next version of the tool will detect this and not complain anymore)
 - 'Any' as well now.
 - `Duration` is used in an error constructor, we don't even want to expose that I believe.

So all good.