### PR TITLE
Rev package:lints

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk: [3.5.0, dev]
+        sdk: [3.5, dev]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk: [3.2.0, dev]
+        sdk: [3.5.0, dev]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [3.2.0, dev]
+        sdk: [3.5.0, dev]
         platform: [vm, chrome]
         exclude:
           # We only run Chrome tests on Linux. No need to run them

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [3.5.0, dev]
+        sdk: [3.5, dev]
         platform: [vm, chrome]
         exclude:
           # We only run Chrome tests on Linux. No need to run them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Small fixes, such as ports in testing and enabling `timeline_test.dart`.
 * When the keep alive manager runs into a timeout, it will finish the transport instead of closing
   the connection, as defined in the gRPC spec.
+* Upgrade to `package:lints` version 5.0.0 and Dart SDK version 3.5.0.
 
 ## 4.0.1
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,12 +9,15 @@ analyzer:
 
 linter:
   rules:
-    - always_declare_return_types
-    - cancel_subscriptions
-    - close_sinks
-    - directives_ordering
-    - omit_local_variable_types
-    - prefer_final_locals
-    - prefer_single_quotes
-    - test_types_in_equals
-    - prefer_relative_imports
+    #true
+    always_declare_return_types: true
+    cancel_subscriptions: true
+    close_sinks: true
+    directives_ordering: true
+    omit_local_variable_types: true
+    prefer_final_locals: true
+    prefer_single_quotes: true
+    test_types_in_equals: true
+    prefer_relative_imports: true
+    #false
+    unintended_html_in_doc_comment: false

--- a/lib/service_api.dart
+++ b/lib/service_api.dart
@@ -16,7 +16,7 @@
 /// Exports the minimum api to define server and client stubs.
 ///
 /// Mainly intended to be imported by generated code.
-library service_api;
+library;
 
 export 'src/client/call.dart' show CallOptions, MetadataProvider;
 export 'src/client/channel.dart' show ClientChannel;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.0.0
   build_test: ^2.0.0
-  lints: ^4.0.0
+  lints: ^5.0.0
   mockito: ^5.0.0
   path: ^1.8.0
   test: ^1.16.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ version: 4.0.2-wip
 repository: https://github.com/grpc/grpc-dart
 
 environment:
-  sdk: ^3.2.0
+  sdk: ^3.5.0
 
 dependencies:
   async: ^2.5.0


### PR DESCRIPTION
Ignore the `unintended_html_in_doc_comment` lint, as the lint fires on generated code from imported protobufs.

Supersedes #739. 