### PR TITLE
fix: Migrate off legacy JS/HTML APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * When the keep alive manager runs into a timeout, it will finish the transport instead of closing
   the connection, as defined in the gRPC spec.
 * Upgrade to `package:lints` version 5.0.0 and Dart SDK version 3.5.0.
+* Update xhr transport to migrate off legacy JS/HTML apis.
 
 ## 4.0.1
 

--- a/lib/grpc_or_grpcweb.dart
+++ b/lib/grpc_or_grpcweb.dart
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'src/client/grpc_or_grpcweb_channel_grpc.dart'
-    if (dart.library.html) 'src/client/grpc_or_grpcweb_channel_web.dart';
+import 'src/client/grpc_or_grpcweb_channel_web.dart'
+    if (dart.library.io) 'src/client/grpc_or_grpcweb_channel_grpc.dart';
 import 'src/client/http2_channel.dart';
 import 'src/client/options.dart';
 

--- a/lib/grpc_or_grpcweb.dart
+++ b/lib/grpc_or_grpcweb.dart
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'src/client/grpc_or_grpcweb_channel_web.dart'
-    if (dart.library.io) 'src/client/grpc_or_grpcweb_channel_grpc.dart';
+import 'src/client/grpc_or_grpcweb_channel_grpc.dart'
+    if (dart.library.js_interop) 'src/client/grpc_or_grpcweb_channel_web.dart';
 import 'src/client/http2_channel.dart';
 import 'src/client/options.dart';
 

--- a/lib/src/client/transport/xhr_transport.dart
+++ b/lib/src/client/transport/xhr_transport.dart
@@ -161,9 +161,7 @@ class XhrClientConnection implements ClientConnection {
 
   void _initializeRequest(
       XMLHttpRequest request, Map<String, String> metadata) {
-    metadata.forEach((key, value) {
-      request.setRequestHeader(key, value);
-    });
+    metadata.forEach(request.setRequestHeader);
     // Overriding the mimetype allows us to stream and parse the data
     request.overrideMimeType('text/plain; charset=x-user-defined');
     request.responseType = 'text';

--- a/lib/src/client/transport/xhr_transport.dart
+++ b/lib/src/client/transport/xhr_transport.dart
@@ -51,7 +51,7 @@ class XhrTransportStream implements GrpcTransportStream {
       : _onError = onError,
         _onDone = onDone {
     _outgoingMessages.stream.map(frame).listen(
-        (data) => _request.send(Int8List.fromList(data).toJS),
+        (data) => _request.send(Uint8List.fromList(data).toJS),
         cancelOnError: true,
         onError: _onError);
 

--- a/lib/src/client/transport/xhr_transport.dart
+++ b/lib/src/client/transport/xhr_transport.dart
@@ -59,14 +59,12 @@ class XhrTransportStream implements GrpcTransportStream {
       if (_incomingProcessor.isClosed) {
         return;
       }
-      switch (_request.readyState) {
-        case 2:
-          _onHeadersReceived();
-          break;
-        case 4:
-          _onRequestDone();
-          _close();
-          break;
+      // TODO: dart-lang/web#285 use 'if' for now
+      if (_request.readyState == XMLHttpRequest.HEADERS_RECEIVED) {
+        _onHeadersReceived();
+      } else if (_request.readyState == XMLHttpRequest.DONE) {
+        _onRequestDone();
+        _close();
       }
     });
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   http2: ^2.2.0
   protobuf: '>=2.0.0 <4.0.0'
   clock: ^1.1.1
+  web: ^1.0.0
 
 dev_dependencies:
   build_runner: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   http2: ^2.2.0
   protobuf: '>=2.0.0 <4.0.0'
   clock: ^1.1.1
-  web: ^1.0.0
+  web: ^1.1.0
 
 dev_dependencies:
   build_runner: ^2.0.0


### PR DESCRIPTION
This is a straightforward rebase of @minoic's https://github.com/grpc/grpc-dart/pull/730 onto the latest master.