### PR TITLE
fix: Use package:web to get HttpStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Upgrade to `package:lints` version 5.0.0 and Dart SDK version 3.5.0.
 * Upgrade `example/grpc-web` code.
 * Update xhr transport to migrate off legacy JS/HTML apis.
+* Use `package:web` to get `HttpStatus`
 
 ## 4.0.1
 

--- a/lib/src/shared/io_bits/io_bits.dart
+++ b/lib/src/shared/io_bits/io_bits.dart
@@ -13,4 +13,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export 'io_bits_io.dart' if (dart.library.html) 'io_bits_web.dart';
+export 'io_bits_io.dart' if (dart.library.js_interop) 'io_bits_web.dart';

--- a/lib/src/shared/io_bits/io_bits_web.dart
+++ b/lib/src/shared/io_bits/io_bits_web.dart
@@ -13,8 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// ignore: deprecated_member_use (#756)
-export 'dart:html' show HttpStatus;
+export 'package:web/web.dart' show HttpStatus;
 
 /// Unavailable on the web
 class InternetAddress {}


### PR DESCRIPTION
Removes HttpStatus from io_bits, thereby breaking the dependency on dart:html.

Code that previously used HttpStatus from dart:html or dart:io now gets it from package:web.

Alternatively, this could instead use HttpStatus from dart:io on platforms with dart:io and get it from package:web only otherwise. If that's preferred we can do it that way.

