### PR TITLE
Fix: Migrate off legacy JS/HTML APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   the connection, as defined in the gRPC spec.
 * Upgrade to `package:lints` version 5.0.0 and Dart SDK version 3.5.0.
 * Upgrade `example/grpc-web` code.
+* Update xhr transport to migrate off legacy JS/HTML apis.
 
 ## 4.0.1
 

--- a/lib/grpc_or_grpcweb.dart
+++ b/lib/grpc_or_grpcweb.dart
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 import 'src/client/grpc_or_grpcweb_channel_grpc.dart'
-    if (dart.library.html) 'src/client/grpc_or_grpcweb_channel_web.dart';
+    if (dart.library.js_interop) 'src/client/grpc_or_grpcweb_channel_web.dart';
 import 'src/client/http2_channel.dart';
 import 'src/client/options.dart';
 

--- a/lib/src/client/transport/xhr_transport.dart
+++ b/lib/src/client/transport/xhr_transport.dart
@@ -31,7 +31,7 @@ import 'web_streams.dart';
 const _contentTypeKey = 'Content-Type';
 
 class XhrTransportStream implements GrpcTransportStream {
-  final XMLHttpRequest _request;
+  final IXMLHttpRequest _request;
   final ErrorHandler _onError;
   final Function(XhrTransportStream stream) _onDone;
   bool _headersReceived = false;
@@ -163,6 +163,7 @@ abstract interface class IXMLHttpRequest {
   set responseType(String responseType);
   set withCredentials(bool withCredentials);
 
+  void abort();
   void open(
     String method,
     String url, [
@@ -210,6 +211,11 @@ class XMLHttpRequestImpl implements IXMLHttpRequest {
   @override
   set withCredentials(bool withCredentials) {
     _xhr.withCredentials = withCredentials;
+  }
+
+  @override
+  void abort() {
+    _xhr.abort();
   }
 
   @override
@@ -301,8 +307,7 @@ class XhrClientConnection implements ClientConnection {
 
   XhrTransportStream _createXhrTransportStream(IXMLHttpRequest request,
       ErrorHandler onError, void Function(XhrTransportStream stream) onDone) {
-    return XhrTransportStream(request.toXMLHttpRequest(),
-        onError: onError, onDone: onDone);
+    return XhrTransportStream(request, onError: onError, onDone: onDone);
   }
 
   void _removeStream(XhrTransportStream stream) {

--- a/lib/src/client/transport/xhr_transport.dart
+++ b/lib/src/client/transport/xhr_transport.dart
@@ -14,11 +14,11 @@
 // limitations under the License.
 
 import 'dart:async';
-// ignore: deprecated_member_use (#756)
-import 'dart:html';
+import 'dart:js_interop';
 import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
+import 'package:web/web.dart';
 
 import '../../client/call.dart';
 import '../../shared/message.dart';
@@ -31,7 +31,7 @@ import 'web_streams.dart';
 const _contentTypeKey = 'Content-Type';
 
 class XhrTransportStream implements GrpcTransportStream {
-  final HttpRequest _request;
+  final XMLHttpRequest _request;
   final ErrorHandler _onError;
   final Function(XhrTransportStream stream) _onDone;
   bool _headersReceived = false;
@@ -50,19 +50,20 @@ class XhrTransportStream implements GrpcTransportStream {
       {required ErrorHandler onError, required onDone})
       : _onError = onError,
         _onDone = onDone {
-    _outgoingMessages.stream
-        .map(frame)
-        .listen((data) => _request.send(data), cancelOnError: true);
+    _outgoingMessages.stream.map(frame).listen(
+        (data) => _request.send(Uint8List.fromList(data).toJS),
+        cancelOnError: true,
+        onError: _onError);
 
-    _request.onReadyStateChange.listen((data) {
+    _request.onReadyStateChange.listen((_) {
       if (_incomingProcessor.isClosed) {
         return;
       }
       switch (_request.readyState) {
-        case HttpRequest.HEADERS_RECEIVED:
+        case XMLHttpRequest.HEADERS_RECEIVED:
           _onHeadersReceived();
           break;
-        case HttpRequest.DONE:
+        case XMLHttpRequest.DONE:
           _onRequestDone();
           _close();
           break;
@@ -82,13 +83,11 @@ class XhrTransportStream implements GrpcTransportStream {
       if (_incomingProcessor.isClosed) {
         return;
       }
-      // Use response over responseText as most browsers don't support
-      // using responseText during an onProgress event.
-      final responseString = _request.response as String;
+      final responseText = _request.responseText;
       final bytes = Uint8List.fromList(
-              responseString.substring(_requestBytesRead).codeUnits)
+              responseText.substring(_requestBytesRead).codeUnits)
           .buffer;
-      _requestBytesRead = responseString.length;
+      _requestBytesRead = responseText.length;
       _incomingProcessor.add(bytes);
     });
 
@@ -123,9 +122,11 @@ class XhrTransportStream implements GrpcTransportStream {
     if (!_headersReceived && !_validateResponseState()) {
       return;
     }
-    if (_request.response == null) {
+    if (_request.status != 200) {
       _onError(
-          GrpcError.unavailable('XhrConnection request null response', null,
+          GrpcError.unavailable(
+              'Request failed with status: ${_request.status}',
+              null,
               _request.responseText),
           StackTrace.current);
       return;
@@ -145,6 +146,104 @@ class XhrTransportStream implements GrpcTransportStream {
   }
 }
 
+// XMLHttpRequest is an extension type and can't be extended or implemented.
+// This interface is used to allow for mocking XMLHttpRequest in tests of
+// XhrClientConnection.
+@visibleForTesting
+abstract interface class IXMLHttpRequest {
+  Stream<Event> get onReadyStateChange;
+  Stream<ProgressEvent> get onProgress;
+  Stream<ProgressEvent> get onError;
+  int get readyState;
+  JSAny? get response;
+  String get responseText;
+  Map<String, String> get responseHeaders;
+  int get status;
+
+  set responseType(String responseType);
+  set withCredentials(bool withCredentials);
+
+  void open(
+    String method,
+    String url, [
+    // external default is true
+    bool async = true,
+    String? username,
+    String? password,
+  ]);
+  void overrideMimeType(String mimeType);
+  void send([JSAny? body]);
+  void setRequestHeader(String header, String value);
+
+  // This method should only be used in production code.
+  XMLHttpRequest toXMLHttpRequest();
+}
+
+// IXMLHttpRequest that delegates to a real XMLHttpRequest.
+class XMLHttpRequestImpl implements IXMLHttpRequest {
+  final XMLHttpRequest _xhr = XMLHttpRequest();
+
+  XMLHttpRequestImpl();
+
+  @override
+  Stream<Event> get onReadyStateChange => _xhr.onReadyStateChange;
+  @override
+  Stream<ProgressEvent> get onProgress => _xhr.onProgress;
+  @override
+  Stream<ProgressEvent> get onError => _xhr.onError;
+  @override
+  int get readyState => _xhr.readyState;
+  @override
+  Map<String, String> get responseHeaders => _xhr.responseHeaders;
+  @override
+  JSAny? get response => _xhr.response;
+  @override
+  String get responseText => _xhr.responseText;
+  @override
+  int get status => _xhr.status;
+
+  @override
+  set responseType(String responseType) {
+    _xhr.responseType = responseType;
+  }
+
+  @override
+  set withCredentials(bool withCredentials) {
+    _xhr.withCredentials = withCredentials;
+  }
+
+  @override
+  void open(
+    String method,
+    String url, [
+    bool async = true,
+    String? username,
+    String? password,
+  ]) {
+    _xhr.open(method, url, async, username, password);
+  }
+
+  @override
+  void overrideMimeType(String mimeType) {
+    _xhr.overrideMimeType(mimeType);
+  }
+
+  @override
+  void setRequestHeader(String header, String value) {
+    _xhr.setRequestHeader(header, value);
+  }
+
+  @override
+  void send([JSAny? body]) {
+    _xhr.send(body);
+  }
+
+  @override
+  XMLHttpRequest toXMLHttpRequest() {
+    return _xhr;
+  }
+}
+
 class XhrClientConnection implements ClientConnection {
   final Uri uri;
 
@@ -154,20 +253,20 @@ class XhrClientConnection implements ClientConnection {
 
   @override
   String get authority => uri.authority;
+
   @override
   String get scheme => uri.scheme;
 
-  void _initializeRequest(HttpRequest request, Map<String, String> metadata) {
-    for (final header in metadata.keys) {
-      request.setRequestHeader(header, metadata[header]!);
-    }
+  void _initializeRequest(
+      IXMLHttpRequest request, Map<String, String> metadata) {
+    metadata.forEach(request.setRequestHeader);
     // Overriding the mimetype allows us to stream and parse the data
     request.overrideMimeType('text/plain; charset=x-user-defined');
     request.responseType = 'text';
   }
 
   @visibleForTesting
-  HttpRequest createHttpRequest() => HttpRequest();
+  IXMLHttpRequest createHttpRequest() => XMLHttpRequestImpl();
 
   @override
   GrpcTransportStream makeRequest(String path, Duration? timeout,
@@ -195,9 +294,15 @@ class XhrClientConnection implements ClientConnection {
     _initializeRequest(request, metadata);
 
     final transportStream =
-        XhrTransportStream(request, onError: onError, onDone: _removeStream);
+        _createXhrTransportStream(request, onError, _removeStream);
     _requests.add(transportStream);
     return transportStream;
+  }
+
+  XhrTransportStream _createXhrTransportStream(IXMLHttpRequest request,
+      ErrorHandler onError, void Function(XhrTransportStream stream) onDone) {
+    return XhrTransportStream(request.toXMLHttpRequest(),
+        onError: onError, onDone: onDone);
   }
 
   void _removeStream(XhrTransportStream stream) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   http2: ^2.2.0
   protobuf: '>=2.0.0 <4.0.0'
   clock: ^1.1.1
+  web: ^1.1.0
 
 dev_dependencies:
   build_runner: ^2.0.0

--- a/test/client_tests/client_xhr_transport_test.dart
+++ b/test/client_tests/client_xhr_transport_test.dart
@@ -17,8 +17,7 @@
 library;
 
 import 'dart:async';
-// ignore: deprecated_member_use (#756)
-import 'dart:html';
+import 'dart:js_interop';
 
 import 'package:async/async.dart';
 import 'package:grpc/src/client/call.dart';
@@ -28,12 +27,13 @@ import 'package:grpc/src/shared/status.dart';
 import 'package:mockito/mockito.dart';
 import 'package:stream_transform/stream_transform.dart';
 import 'package:test/test.dart';
+import 'package:web/web.dart';
 
 final readyStateChangeEvent =
-    Event('readystatechange', canBubble: false, cancelable: false);
+    Event('readystatechange', EventInit(bubbles: false, cancelable: false));
 final progressEvent = ProgressEvent('onloadstart');
 
-class MockHttpRequest extends Mock implements HttpRequest {
+class MockHttpRequest extends Mock implements IXMLHttpRequest {
   MockHttpRequest({int? code}) : status = code ?? 200;
   // ignore: close_sinks
   StreamController<Event> readyStateChangeController =
@@ -54,6 +54,10 @@ class MockHttpRequest extends Mock implements HttpRequest {
   @override
   final int status;
 
+  // Some test code expects to call this
+  set readyState(int state);
+  set responseText(String text);
+
   @override
   int get readyState =>
       super.noSuchMethod(Invocation.getter(#readyState), returnValue: -1);
@@ -73,7 +77,7 @@ class MockXhrClientConnection extends XhrClientConnection {
   final int _statusCode;
 
   @override
-  HttpRequest createHttpRequest() {
+  IXMLHttpRequest createHttpRequest() {
     final request = MockHttpRequest(code: _statusCode);
     latestRequest = request;
     return request;
@@ -210,8 +214,7 @@ void main() {
     await stream.terminate();
 
     final expectedData = frame(data);
-    expect(verify(connection.latestRequest.send(captureAny)).captured.single,
-        expectedData);
+    verify(connection.latestRequest.send(expectedData.toJSBox));
   });
 
   test('Stream handles headers properly', () async {
@@ -228,15 +231,15 @@ void main() {
 
     when(transport.latestRequest.responseHeaders).thenReturn(responseHeaders);
     when(transport.latestRequest.response)
-        .thenReturn(String.fromCharCodes(frame(<int>[])));
+        .thenReturn(String.fromCharCodes(frame(<int>[])).toJS);
 
     // Set expectation for request readyState and generate two readyStateChange
     // events, so that incomingMessages stream completes.
-    final readyStates = [HttpRequest.HEADERS_RECEIVED, HttpRequest.DONE];
-    when(transport.latestRequest.readyState)
-        .thenAnswer((_) => readyStates.removeAt(0));
+    final readyStates = [XMLHttpRequest.HEADERS_RECEIVED, XMLHttpRequest.DONE];
+    transport.latestRequest.readyState = readyStates[0];
     transport.latestRequest.readyStateChangeController
         .add(readyStateChangeEvent);
+    transport.latestRequest.readyState = readyStates[1];
     transport.latestRequest.readyStateChangeController
         .add(readyStateChangeEvent);
 
@@ -269,16 +272,15 @@ void main() {
     final encodedString = String.fromCharCodes(encodedTrailers);
 
     when(connection.latestRequest.responseHeaders).thenReturn(requestHeaders);
-    when(connection.latestRequest.response).thenReturn(encodedString);
+    when(connection.latestRequest.response).thenReturn(encodedString.toJS);
 
     // Set expectation for request readyState and generate events so that
     // incomingMessages stream completes.
-    final readyStates = [HttpRequest.HEADERS_RECEIVED, HttpRequest.DONE];
-    when(connection.latestRequest.readyState)
-        .thenAnswer((_) => readyStates.removeAt(0));
+    connection.latestRequest.readyState = XMLHttpRequest.HEADERS_RECEIVED;
     connection.latestRequest.readyStateChangeController
         .add(readyStateChangeEvent);
     connection.latestRequest.progressController.add(progressEvent);
+    connection.latestRequest.readyState = XMLHttpRequest.DONE;
     connection.latestRequest.readyStateChangeController
         .add(readyStateChangeEvent);
 
@@ -305,16 +307,14 @@ void main() {
     final encodedString = String.fromCharCodes(encoded);
 
     when(connection.latestRequest.responseHeaders).thenReturn(requestHeaders);
-    when(connection.latestRequest.response).thenReturn(encodedString);
-
+    when(connection.latestRequest.response).thenReturn(encodedString.toJS);
     // Set expectation for request readyState and generate events so that
     // incomingMessages stream completes.
-    final readyStates = [HttpRequest.HEADERS_RECEIVED, HttpRequest.DONE];
-    when(connection.latestRequest.readyState)
-        .thenAnswer((_) => readyStates.removeAt(0));
+    connection.latestRequest.readyState = XMLHttpRequest.HEADERS_RECEIVED;
     connection.latestRequest.readyStateChangeController
         .add(readyStateChangeEvent);
     connection.latestRequest.progressController.add(progressEvent);
+    connection.latestRequest.readyState = XMLHttpRequest.DONE;
     connection.latestRequest.readyStateChangeController
         .add(readyStateChangeEvent);
 
@@ -340,16 +340,15 @@ void main() {
     final data = List<int>.filled(10, 224);
     when(connection.latestRequest.responseHeaders).thenReturn(requestHeaders);
     when(connection.latestRequest.response)
-        .thenReturn(String.fromCharCodes(frame(data)));
+        .thenReturn(String.fromCharCodes(frame(data)).toJS);
 
     // Set expectation for request readyState and generate events, so that
     // incomingMessages stream completes.
-    final readyStates = [HttpRequest.HEADERS_RECEIVED, HttpRequest.DONE];
-    when(connection.latestRequest.readyState)
-        .thenAnswer((_) => readyStates.removeAt(0));
+    connection.latestRequest.readyState = XMLHttpRequest.HEADERS_RECEIVED;
     connection.latestRequest.readyStateChangeController
         .add(readyStateChangeEvent);
     connection.latestRequest.progressController.add(progressEvent);
+    connection.latestRequest.readyState = XMLHttpRequest.DONE;
     connection.latestRequest.readyStateChangeController
         .add(readyStateChangeEvent);
 
@@ -371,8 +370,8 @@ void main() {
     const errorDetails = 'error details';
     when(connection.latestRequest.responseHeaders)
         .thenReturn({'content-type': 'application/grpc+proto'});
-    when(connection.latestRequest.readyState).thenReturn(HttpRequest.DONE);
-    when(connection.latestRequest.responseText).thenReturn(errorDetails);
+    connection.latestRequest.readyState = XMLHttpRequest.DONE;
+    connection.latestRequest.responseText = errorDetails;
     connection.latestRequest.readyStateChangeController
         .add(readyStateChangeEvent);
     await errorReceived.future;
@@ -400,7 +399,7 @@ void main() {
 
     when(connection.latestRequest.responseHeaders).thenReturn(metadata);
     when(connection.latestRequest.readyState)
-        .thenReturn(HttpRequest.HEADERS_RECEIVED);
+        .thenReturn(XMLHttpRequest.HEADERS_RECEIVED);
 
     // At first invocation the response should be the the first message, after
     // that first + last messages.
@@ -408,12 +407,12 @@ void main() {
     when(connection.latestRequest.response).thenAnswer((_) {
       if (first) {
         first = false;
-        return encodedStrings[0];
+        return encodedStrings[0].toJS;
       }
-      return encodedStrings[0] + encodedStrings[1];
+      return (encodedStrings[0] + encodedStrings[1]).toJS;
     });
 
-    final readyStates = [HttpRequest.HEADERS_RECEIVED, HttpRequest.DONE];
+    final readyStates = [XMLHttpRequest.HEADERS_RECEIVED, XMLHttpRequest.DONE];
     when(connection.latestRequest.readyState)
         .thenAnswer((_) => readyStates.removeAt(0));
 


### PR DESCRIPTION
Fixes #715.

This includes a rebase of @minoic's https://github.com/grpc/grpc-dart/pull/730 onto the latest master, along with a couple updates.

It also updates client_xhr_transport_test to avoid dart:html, performing some ceremony to work around the unavailability of the previous mock strategy. 

