### PR TITLE
Allow the latest pkg:googleapis_auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.4
+
+* Allow the latest `package:googleapis_auth`.
+
 ## 4.0.3
 
 * Widen `package:protobuf` constraint to allow version 4.0.0.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   async: ^2.5.0
   crypto: ^3.0.0
   fixnum: ^1.0.0
-  googleapis_auth: ">=1.0.0 <3.0.0"
+  googleapis_auth: ">=1.1.0 <3.0.0"
   meta: ^1.3.0
   http: ">=0.13.0 <2.0.0"
   http2: ^2.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: grpc
-version: 4.0.3
+version: 4.0.4
 description: Dart implementation of gRPC, a high performance, open-source universal RPC framework.
 repository: https://github.com/grpc/grpc-dart
 
@@ -15,7 +15,7 @@ dependencies:
   async: ^2.5.0
   crypto: ^3.0.0
   fixnum: ^1.0.0
-  googleapis_auth: ^1.1.0
+  googleapis_auth: ">=1.0.0 <3.0.0"
   meta: ^1.3.0
   http: ">=0.13.0 <2.0.0"
   http2: ^2.2.0


### PR DESCRIPTION
Closes https://github.com/grpc/grpc-dart/pull/772
