### PR TITLE
Fix CallOptions.mergeWith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 4.1.0
-* Add a `serverInterceptors` argument to `ConnectionServer`. These interceptors are acting 
+* Add a `serverInterceptors` argument to `ConnectionServer`. These interceptors are acting
   as middleware, wrapping a `ServiceMethod` invocation.
+* Make sure that `CallOptions.mergeWith` is symmetric: given `WebCallOptions`
+  it should return `WebCallOptions`.
 
 ## 4.0.4
 

--- a/lib/src/client/call.dart
+++ b/lib/src/client/call.dart
@@ -86,6 +86,11 @@ class CallOptions {
 
   CallOptions mergedWith(CallOptions? other) {
     if (other == null) return this;
+
+    if (other is WebCallOptions) {
+      return other.mergedWith(this);
+    }
+
     final mergedMetadata = Map.of(metadata)..addAll(other.metadata);
     final mergedTimeout = other.timeout ?? timeout;
     final mergedProviders = List.of(metadataProviders)

--- a/test/client_tests/call_test.dart
+++ b/test/client_tests/call_test.dart
@@ -34,15 +34,20 @@ void main() {
   });
 
   test('WebCallOptions mergeWith CallOptions returns WebCallOptions', () {
-    final options =
+    final options1 =
         WebCallOptions(bypassCorsPreflight: true, withCredentials: true);
     final metadata = {'test': '42'};
-    final mergedOptions =
-        options.mergedWith(CallOptions(metadata: metadata)) as WebCallOptions;
+    final options2 = CallOptions(metadata: metadata);
+    final mergedOptions1 = options1.mergedWith(options2) as WebCallOptions;
+    final mergedOptions2 = options2.mergedWith(options1) as WebCallOptions;
 
-    expect(mergedOptions.metadata, metadata);
-    expect(mergedOptions.bypassCorsPreflight, true);
-    expect(mergedOptions.withCredentials, true);
+    expect(mergedOptions1.metadata, metadata);
+    expect(mergedOptions1.bypassCorsPreflight, true);
+    expect(mergedOptions1.withCredentials, true);
+
+    expect(mergedOptions2.metadata, metadata);
+    expect(mergedOptions2.bypassCorsPreflight, true);
+    expect(mergedOptions2.withCredentials, true);
   });
 
   test(


### PR DESCRIPTION
It should have symmetric behavior: given `WebCallOptions a` and `CallOptions b` both `a.mergeWith(b)` and `b.mergeFrom(a)` should return `WebCallOptions`.