### PR TITLE
Pub workspace

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -29,15 +29,6 @@ jobs:
       - name: Check formatting (using dev dartfmt release)
         if: ${{ matrix.sdk == 'stable' }}
         run: dart format --output=none --set-exit-if-changed .
-      - name: Analyze code (introp and examples)
-        run: |
-          for example in interop example/*/; do
-            pushd $example
-            echo [Getting dependencies in $example]
-            dart pub get
-            popd
-          done
-        shell: bash
       - name: Analyze code
         run: dart analyze --fatal-infos .
       - name: Check that grpc-web sample builds with DDC

--- a/example/googleapis/pubspec.yaml
+++ b/example/googleapis/pubspec.yaml
@@ -2,15 +2,16 @@ name: googleapis
 description: Dart gRPC client sample for Google APIs
 publish_to: none
 
+resolution: workspace
+
 environment:
   sdk: ^3.8.0
 
 dependencies:
-  async: ^2.13.0
-  fixnum: ^1.1.1
-  grpc:
-    path: ../../
-  protobuf: ^4.1.0
+  async: any
+  fixnum: any
+  grpc: any
+  protobuf: any
 
 dev_dependencies:
   lints: ^6.0.0

--- a/example/grpc-web/pubspec.yaml
+++ b/example/grpc-web/pubspec.yaml
@@ -2,14 +2,15 @@ name: grpc_web
 description: Dart gRPC-Web sample client
 publish_to: none
 
+resolution: workspace
+
 environment:
   sdk: ^3.8.0
 
 dependencies:
-  grpc:
-    path: ../../
-  protobuf: ^4.1.0
-  web: ^1.1.1
+  grpc: any
+  protobuf: any
+  web: any
 
 dev_dependencies:
   build_runner: ^2.4.15

--- a/example/helloworld/pubspec.yaml
+++ b/example/helloworld/pubspec.yaml
@@ -2,14 +2,15 @@ name: helloworld
 description: Dart gRPC sample client and server.
 publish_to: none
 
+resolution: workspace
+
 environment:
   sdk: ^3.8.0
 
 dependencies:
-  async: ^2.13.0
-  grpc:
-    path: ../../
-  protobuf: ^4.1.0
+  async: any
+  grpc: any
+  protobuf: any
 
 dev_dependencies:
   lints: ^6.0.0

--- a/example/metadata/pubspec.yaml
+++ b/example/metadata/pubspec.yaml
@@ -2,14 +2,15 @@ name: metadata
 description: Dart gRPC sample client and server.
 publish_to: none
 
+resolution: workspace
+
 environment:
   sdk: ^3.8.0
 
 dependencies:
-  async: ^2.13.0
-  grpc:
-    path: ../../
-  protobuf: ^4.1.0
+  async: any
+  grpc: any
+  protobuf: any
 
 dev_dependencies:
   lints: ^6.0.0

--- a/example/route_guide/pubspec.yaml
+++ b/example/route_guide/pubspec.yaml
@@ -2,15 +2,16 @@ name: route_guide
 description: Dart gRPC sample client and server.
 publish_to: none
 
+resolution: workspace
+
 environment:
   sdk: ^3.8.0
 
 dependencies:
-  async: ^2.13.0
-  collection: ^1.19.1
-  grpc:
-    path: ../../
-  protobuf: ^4.1.0
+  async: any
+  collection: any
+  grpc: any
+  protobuf: any
 
 dev_dependencies:
   lints: ^6.0.0

--- a/interop/pubspec.yaml
+++ b/interop/pubspec.yaml
@@ -2,16 +2,17 @@ name: interop
 description: Dart gRPC interoperability test suite.
 publish_to: none
 
+resolution: workspace
+
 environment:
   sdk: ^3.8.0
 
 dependencies:
-  args: ^2.7.0
-  async: ^2.13.0
-  collection: ^1.19.1
-  grpc:
-    path: ../
-  protobuf: ^4.1.0
+  args: any
+  async: any
+  collection: any
+  grpc: any
+  protobuf: any
 
 dev_dependencies:
   lints: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,6 +3,14 @@ version: 4.2.0
 description: Dart implementation of gRPC, a high performance, open-source universal RPC framework.
 repository: https://github.com/grpc/grpc-dart
 
+workspace:
+  - example/googleapis
+  - example/grpc-web
+  - example/helloworld
+  - example/metadata
+  - example/route_guide
+  - interop
+
 topics:
   - grpc
   - protocols


### PR DESCRIPTION
Transform into a pub workspace with `any` dependencies on the examples, as they are not published. Makes revving versions easier.