### PR TITLE
Skip handling when handler is closed to prevent processing on canceled calls

### DIFF
--- a/lib/src/server/handler.dart
+++ b/lib/src/server/handler.dart
@@ -151,6 +151,7 @@ class ServerHandler extends ServiceCall {
   // -- Idle state, incoming data --
 
   void _onDataIdle(GrpcMessage headerMessage) async {
+    if (isCanceled) return;
     onDataReceived?.add(null);
     if (headerMessage is! GrpcMetadata) {
       _sendError(GrpcError.unimplemented('Expected header frame'));
@@ -276,6 +277,7 @@ class ServerHandler extends ServiceCall {
   // -- Active state, incoming data --
 
   void _onDataActive(GrpcMessage message) {
+    if (isCanceled) return;
     if (message is! GrpcData) {
       final error = GrpcError.unimplemented('Expected request');
       _sendError(error);
@@ -316,6 +318,7 @@ class ServerHandler extends ServiceCall {
   // -- Active state, outgoing response data --
 
   void _onResponse(dynamic response) {
+    if (isCanceled) return;
     try {
       final bytes = _descriptor.serialize(response);
       if (!_headersSent) {
@@ -336,10 +339,12 @@ class ServerHandler extends ServiceCall {
   }
 
   void _onResponseDone() {
+    if (isCanceled) return;
     sendTrailers();
   }
 
   void _onResponseError(Object error, StackTrace trace) {
+    if (isCanceled) return;
     if (error is GrpcError) {
       _sendError(error, trace);
     } else {
@@ -443,6 +448,7 @@ class ServerHandler extends ServiceCall {
   }
 
   void _onDoneExpected() {
+    if (isCanceled) return;
     if (!(_hasReceivedRequest || _descriptor.streamingRequest)) {
       final error = GrpcError.unimplemented('No request received');
       _sendError(error);


### PR DESCRIPTION
## Summary
This PR fixes a critical server-side crash occurring when a gRPC client disconnects immediately after initiating a request. This issue typically results in an unhandled `Bad state: Cannot add event after closing` error, which brings down the entire server process.

## Related Issues
Fixes #67 and #558 . This behavior has been reported previously but remained unresolved until now.

## The Problem
When a client terminates abruptly (e.g., a process crash or network drop) immediately after sending a request, the server-side stream may transition to a closed state while the handler is still attempting to send data or events back. Attempting to interact with the closed stream without a state check throws a fatal "Bad state" exception.

As a matter of principle, a client-side disconnection should never be able to compromise the stability of the server process.

## The Solution
The fix introduces a safety check on the isCanceled flag prior to any interaction with the client stream. This ensures that if the connection is already dead, the server gracefully handles the state rather than attempting to write to a closed sink.

## How to Reproduce

1. Start the gRPC server.
2. Run the following Go script. It opens a stream, sends a single message, and then calls os.Exit(0) to simulate an abrupt termination without a clean shutdown.
3. Observe the server logs for the Bad state: Cannot add event after closing crash.

```GO
package main

import (
	"context"
	"log"
	"os"
	"time"

	pb "your/module/path/protos" 
	"google.golang.org/grpc"
)

func main() {
	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
	defer cancel()

	conn, err := grpc.DialContext(ctx, "localhost:50051",
		grpc.WithInsecure(),
		grpc.WithBlock(),
		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
	)
	if err != nil {
		log.Fatalf("dial: %v", err)
	}

	client := pb.NewMyServiceClient(conn)
	stream, err := client.Chat(ctx) 
	if err != nil {
		log.Fatalf("open stream: %v", err)
	}

	if err := stream.Send(&pb.ChatRequest{Message: "hi"}); err != nil {
		log.Fatalf("send: %v", err)
	}

	// Terminate immediately to mimic abrupt client death.
	os.Exit(0)
}
```