### PR TITLE
feat(transport): add sourceAddress to ChannelOptions; notify active calls on disconnect

### DIFF
--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -207,8 +207,17 @@ class Http2ClientConnection implements connection.ClientConnection {
     );
   }
 
+  /// Calls that have been dispatched to an active transport stream.
+  /// When the connection is torn down (connectionTimeout-triggered refresh or
+  /// shutdown), active calls are notified via [onConnectionError] so they
+  /// surface as errors rather than hanging indefinitely.
+  /// See: https://github.com/grpc/grpc-dart/issues/752
+  final Set<ClientCall> _activeCalls = {};
+
   void _startCall(ClientCall call) {
     if (call.isCancelled) return;
+    _activeCalls.add(call);
+    call.onDone.then((_) => _activeCalls.remove(call));
     call.onConnectionReady(this);
   }
 
@@ -307,6 +316,15 @@ class Http2ClientConnection implements connection.ClientConnection {
     _transportConnection = null;
     keepAliveManager?.onTransportTermination();
     keepAliveManager = null;
+    if (_activeCalls.isNotEmpty) {
+      final error = GrpcError.unavailable(
+        'Connection reset: connectionTimeout exceeded or transport closed',
+      );
+      for (final call in List.of(_activeCalls)) {
+        call.onConnectionError(error);
+      }
+      _activeCalls.clear();
+    }
   }
 
   void _abandonConnection() {
@@ -414,7 +432,12 @@ class SocketTransportConnector implements ClientTransportConnector {
   }
 
   Future<Socket> initSocket(Object host, int port) async {
-    return await Socket.connect(host, port, timeout: _options.connectTimeout);
+    return await Socket.connect(
+      host,
+      port,
+      timeout: _options.connectTimeout,
+      sourceAddress: _options.sourceAddress,
+    );
   }
 
   void _sendConnect(Map<String, String> headers) {

--- a/lib/src/client/options.dart
+++ b/lib/src/client/options.dart
@@ -62,6 +62,16 @@ class ChannelOptions {
   final ClientKeepAliveOptions keepAlive;
   final Proxy? proxy;
 
+  /// The local address to bind when creating the socket connection.
+  ///
+  /// Accepts [InternetAddress] or [String]. Passed directly to
+  /// [Socket.connect]'s `sourceAddress` parameter. Useful on IVI Linux
+  /// head-units that communicate via a specific loopback interface or when
+  /// the outgoing interface must be pinned for routing purposes.
+  /// Defaults to null (OS assigns the source address).
+  /// See: https://github.com/grpc/grpc-dart/issues/758
+  final Object? sourceAddress;
+
   const ChannelOptions({
     this.credentials = const ChannelCredentials.secure(),
     this.idleTimeout = defaultIdleTimeout,
@@ -72,5 +82,6 @@ class ChannelOptions {
     this.codecRegistry,
     this.keepAlive = const ClientKeepAliveOptions(),
     this.proxy,
+    this.sourceAddress,
   });
 }


### PR DESCRIPTION
## Summary

This PR addresses two related transport-layer issues that affect long-lived gRPC clients on IVI head-units.

---

### Fix #758 — `sourceAddress` in `ChannelOptions`

**Problem**: There is no way to bind the outgoing socket to a specific local address. On IVI Linux head-units with multiple network interfaces, the OS may select the wrong source interface.

**Fix**: Add `sourceAddress` field to `ChannelOptions` (type `Object?`, accepting `InternetAddress` or `String`). Wire it through `initSocket` → `Socket.connect(sourceAddress: ...)`.

```dart
// Usage
final channel = ClientChannel(
  'databroker.local',
  options: ChannelOptions(sourceAddress: InternetAddress('192.168.100.10')),
);
```

Default `null` — no behaviour change for existing users.

---

### Fix #752 — Active call death notification on connection reset

**Problem**: When `_disconnect()` fires (connectionTimeout exceeded, transport closed), active calls hang indefinitely. The `onDone` callback is never invoked. Users resort to polling timeouts.

**Fix**: Add `_activeCalls` registry (`Set<ClientCall>`) in `Http2ClientConnection`. Calls register on `_startCall` and deregister via `call.onDone`. On `_disconnect`, all registered calls receive `onConnectionError(GrpcError.unavailable(...))` so they surface as errors immediately.

**Impact**: Navigation telemetry subscriptions and long-lived vehicle signal streams can now detect connection loss and reconnect cleanly, without a polling heartbeat.

---

## Files changed

| File | Change |
|------|--------|
| `lib/src/client/options.dart` | Add `sourceAddress` field + constructor parameter |
| `lib/src/client/http2_connection.dart` | Wire `sourceAddress` in `initSocket`; add `_activeCalls` + death notification in `_disconnect` |

---

*AI-assisted — authored with Claude, reviewed by Komada.*