### PR TITLE
Enable UDS tests on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.1.1
+
+- Enable Unix domain sockets (UDS) tests on Windows, and modify README to
+  indicate UDS are supported (requires Dart SDK >= 3.11.0, minimum version
+  in `pubspec.yaml` is not bumped as later SDK are only needed for UDS support).
+
 ## 5.1.0
 
 - Added `protos.dart` library.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For complete documentation, see [Dart gRPC](https://grpc.io/docs/languages/dart)
 - [Flutter](https://flutter.dev)
 
 > **Note:** [grpc-web](https://github.com/grpc/grpc-web) is supported by `package:grpc/grpc_web.dart`.
-> **UDS-unix domain socket** is supported with sdk version >= 2.8.0.
+> **UDS-unix domain socket** is supported with sdk version >= 2.8.0 (>= 3.11.0 on Windows).
 
 ## Contributing
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: grpc
-version: 5.1.0
+version: 5.1.1
 description: Dart implementation of gRPC, a high performance, open-source universal RPC framework.
 repository: https://github.com/grpc/grpc-dart
 

--- a/test/common.dart
+++ b/test/common.dart
@@ -18,10 +18,6 @@ import 'package:test/test.dart';
 
 /// Test functionality for Unix domain socket.
 void testUds(String name, FutureOr<void> Function(InternetAddress) testCase) {
-  if (Platform.isWindows) {
-    return;
-  }
-
   test(name, () async {
     final tempDir = await Directory.systemTemp.createTemp();
     final address = InternetAddress(

--- a/test/round_trip_test.dart
+++ b/test/round_trip_test.dart
@@ -158,7 +158,7 @@ Future<void> main() async {
       2,
       3,
     ]);
-    server.shutdown();
+    await server.shutdown();
   });
 
   testTcpAndUds('round trip with outgoing and incoming compression', (
@@ -223,7 +223,7 @@ Future<void> main() async {
       2,
       3,
     ]);
-    server.shutdown();
+    await server.shutdown();
   });
 
   test('exception in onMetadataException', () async {


### PR DESCRIPTION
AF_UNIX support landed in Dart SDK 3.11.0 (Flutter 3.41.0), so the
Windows skip in `testUds` is no longer needed.

Closes #735

- dart-lang fix https://github.com/dart-lang/sdk/commit/e50d3b98a3569e8ecb884f9acb53387a6f5af75d
- I didn't bump the SDK requirement. If users want the feature on Windows, they need to upgrade. Otherwise, the current 3.8.0 should be fine. And I believe you mostly test using stable Flutter releases which should be way past 3.41.0.