### PR TITLE
fix(client): keepalive ping timeout must terminate(), not finish(), the transport

### DIFF
--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -115,10 +115,20 @@ class Http2ClientConnection implements connection.ClientConnection {
               options: options.keepAlive,
               ping: () {
                 if (transport.isOpen) {
-                  transport.ping();
+                  // Errors are handled via the keepalive timeout; the
+                  // returned future errors when terminate() tears the
+                  // transport down mid-ping and must not surface as an
+                  // unhandled async exception.
+                  transport.ping().catchError((_) {});
                 }
               },
-              onPingTimeout: () => transport.finish(),
+              // terminate(), not finish(): finish() waits for active
+              // streams to drain, which never happens on a silently
+              // partitioned connection — the exact condition keepalive
+              // exists to detect. terminate() hard-closes the transport
+              // so in-flight calls fail fast (matches gRPC C-core
+              // keepalive watchdog behavior).
+              onPingTimeout: () => transport.terminate(),
             );
             transport.onFrameReceived.listen(
               (_) => keepAliveManager?.onFrameReceived(),


### PR DESCRIPTION
Fixes #829.

`ClientKeepAlive` detects an unACKed keepalive ping, but the timeout path calls `transport.finish()`, which waits for active streams to drain — never, on a silently partitioned connection (NAT timeout, route black-hole). The watchdog fires and nothing user-visible happens: in-flight calls hang until the OS TCP timeout, and new calls dispatched to the same connection hang too, defeating the purpose of keepalive.

This PR:
- `onPingTimeout: () => transport.terminate()` — hard-close so pending calls fail fast with an HTTP/2 connection error and the channel reconnects on next use. Matches gRPC C-core keepalive watchdog semantics ("keepalive watchdog fired. Closing transport.").
- Guards the unawaited `transport.ping()` future: `terminate()` errors the outstanding ping future via `PingHandler.onTerminated`, which otherwise surfaces as an unhandled async exception. Ping failure is already handled by the keepalive timeout, so the error is intentionally swallowed.

Verified with a protocol-level repro (minimal HTTP/2 peer that completes the SETTINGS exchange and ACKs PINGs, then silently stops ACKing while staying TCP-alive):
- before: held call never errors (>60s observed) after the ping timeout fires;
- after: held call fails within `pingInterval + timeout` (~40s for 30s/10s), and a subsequent call opens a fresh connection; no unhandled async exceptions.